### PR TITLE
moved out keyup and keydown event listeners on higher level

### DIFF
--- a/src/renderer/app/components/BookmarkItem/index.tsx
+++ b/src/renderer/app/components/BookmarkItem/index.tsx
@@ -10,33 +10,21 @@ import { databases } from '~/defaults/databases';
 
 export interface Props {
   data: Bookmark;
+  cmdPressed: boolean;
 }
 
 @observer
 export default class BookmarkItem extends React.Component<Props> {
-  private cmdPressed = false;
 
   private input: HTMLInputElement;
 
-  public componentDidMount() {
-    window.addEventListener('keydown', e => {
-      this.cmdPressed = e.key === 'Meta'; // Command on macOS
-    });
-
-    window.addEventListener('keyup', e => {
-      if (e.key === 'Meta') {
-        this.cmdPressed = false;
-      }
-    });
-  }
-
   public onClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    const { data } = this.props;
+    const { data, cmdPressed } = this.props;
 
     const { bookmarksStore } = store;
     const { selectedItems } = bookmarksStore;
 
-    if (this.cmdPressed || e.ctrlKey) {
+    if (cmdPressed || e.ctrlKey) {
       if (selectedItems.indexOf(data._id) === -1) {
         selectedItems.push(data._id);
       } else {

--- a/src/renderer/app/components/Bookmarks/index.tsx
+++ b/src/renderer/app/components/Bookmarks/index.tsx
@@ -9,8 +9,20 @@ import BookmarkItem from '../BookmarkItem';
 
 @observer
 export default class Bookmarks extends React.Component {
+  private cmdPressed = false;
+
   public async componentDidMount() {
     store.bookmarksStore.goToFolder(null);
+
+    window.addEventListener('keydown', e => {
+      this.cmdPressed = e.key === 'Meta'; // Command on macOS
+    });
+
+    window.addEventListener('keyup', e => {
+      if (e.key === 'Meta') {
+        this.cmdPressed = false;
+      }
+    });
   }
 
   public render() {
@@ -26,7 +38,7 @@ export default class Bookmarks extends React.Component {
             {items.length > 0 && (
               <Items>
                 {items.map(data => (
-                  <BookmarkItem data={data} key={data._id} />
+                  <BookmarkItem cmdPressed={this.cmdPressed} data={data} key={data._id} />
                 ))}
               </Items>
             )}


### PR DESCRIPTION
I've moved out event listeners for keyup and keydown from bookmark item into bookmarks component. Previously, for each bookmark item created its own listener, so there are was ton of them when I've created pretty huge amount of bookmark items. 