### PR TITLE
fix: tabs.executeScript() should respond to correct event

### DIFF
--- a/src/extensions/api/tabs.ts
+++ b/src/extensions/api/tabs.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { API } from '.';
 import { IpcEvent } from '..';
+import { makeId } from '~/shared/utils/string';
 
 let api: API;
 let currentTabId: number;
@@ -122,10 +123,11 @@ export class Tabs {
         );
       }
 
-      ipcRenderer.send('api-tabs-executeScript', tabId, details);
+      const responseId = makeId(32);
+      ipcRenderer.send('api-tabs-executeScript', tabId, details, responseId);
 
       ipcRenderer.once(
-        'api-tabs-executeScript',
+        `api-tabs-executeScript-${responseId}`,
         (e: Electron.IpcMessageEvent, result: any) => {
           if (callback) {
             callback(result);

--- a/src/main/extensions.ts
+++ b/src/main/extensions.ts
@@ -193,12 +193,12 @@ ipcMain.on(
 
 ipcMain.on(
   'api-tabs-executeScript',
-  (e: IpcMessageEvent, tabId: number, details: chrome.tabs.InjectDetails) => {
+  (e: IpcMessageEvent, tabId: number, details: chrome.tabs.InjectDetails, responseId: string) => {
     const view = appWindow.viewManager.views[tabId];
 
     if (view) {
       view.webContents.executeJavaScript(details.code, false, (result: any) => {
-        view.webContents.send('api-tabs-executeScript', result);
+        e.sender.send(`api-tabs-executeScript-${responseId}`, result);
       });
     }
   },
@@ -316,7 +316,7 @@ ipcMain.on('api-alarms-operation', (e: IpcMessageEvent, data: any) => {
       scheduledTime = Date.now() + alarmInfo.delayInMinutes * 60000;
     }
 
-    const alarm: Alarm = {
+    const alarm: chrome.alarms.Alarm = {
       periodInMinutes: alarmInfo.periodInMinutes,
       scheduledTime,
       name,


### PR DESCRIPTION
@sentialx This change ensures that `tabs.executeScript()` will respond to the correct callback regardless of its source. 