### PR TITLE
fix: Support an additional combination of sendMessage parameters

### DIFF
--- a/src/extensions/api/runtime.ts
+++ b/src/extensions/api/runtime.ts
@@ -52,6 +52,10 @@ export class Runtime {
       responseCallback = args[1];
     }
 
+    if (typeof args[2] === 'function') {
+      responseCallback = args[2];
+    }
+
     if (options && options.includeTlsChannelId) {
       sender.tlsChannelId = portId;
     }


### PR DESCRIPTION
@sentialx This change adds support for the combination of optional parameters in `chrome.runtime.sendMessage()` where the `extensionId`, `message`, and `responseCallback` parameters are defined, but the optional `options` parameter is not.

See https://developers.chrome.com/extensions/runtime#method-sendMessage