### PR TITLE
fix: Content script css never loads

### DIFF
--- a/src/preloads/view-preload.ts
+++ b/src/preloads/view-preload.ts
@@ -191,12 +191,9 @@ const runContentScript = (
 
 const runStylesheet = (url: string, code: string) => {
   const wrapper = `((code) => {
-    function init() {
-      const styleElement = document.createElement('style');
-      styleElement.textContent = code;
-      document.head.append(styleElement);
-    }
-    document.addEventListener('DOMContentLoaded', init);
+    const styleElement = document.createElement('style');
+    styleElement.textContent = code;
+    document.head.append(styleElement);
   })`;
 
   const compiledWrapper = runInThisContext(wrapper, {


### PR DESCRIPTION
@sentialx This fixes an issue where the content script CSS never loads. The `runStylesheet()` function is triggered by `DOMContentLoaded` in order to run code defined in `wrapper`. However, this code never runs because it also depends on the `DOMContentLoaded` event which has already fired. 