### PR TITLE
feat: add keyboard shortcuts

### DIFF
--- a/src/constants/tabs.ts
+++ b/src/constants/tabs.ts
@@ -1,0 +1,6 @@
+export const NEWTAB_URL = 'about:blank';
+
+export const defaultTabOptions: chrome.tabs.CreateProperties = {
+  url: NEWTAB_URL,
+  active: true,
+};

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,7 +15,7 @@ import { checkFiles } from '~/utils/files';
 import { DEFAULT_SETTINGS } from '~/constants';
 import { windowManager } from 'node-window-manager';
 
-process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = true;
+(process.env as any)['ELECTRON_DISABLE_SECURITY_WARNINGS'] = true;
 
 export const log = require('electron-log');
 
@@ -162,7 +162,6 @@ app.on('ready', async () => {
   }
 
   runAdblockService(viewSession);
-
   runAutoUpdaterService(appWindow);
 });
 

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -69,6 +69,13 @@ export const getMainMenu = (appWindow: AppWindow) => {
             appWindow.webContents.send('toggle-overlay');
           },
         },
+        {
+          accelerator: 'CmdOrCtrl+L',
+          label: 'Toggle Overlay',
+          click() {
+            appWindow.webContents.send('toggle-overlay');
+          },
+        },
       ],
     },
   ]);

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -21,11 +21,7 @@ export const getMainMenu = (appWindow: AppWindow) => {
           label: 'Reload',
           accelerator: 'CmdOrCtrl+R',
           click: () => {
-            if (process.env.ENV === 'dev') {
-              appWindow.webContents.reload();
-            } else {
-              appWindow.viewManager.selected.webContents.reload();
-            }
+            appWindow.viewManager.selected.webContents.reload();
           },
         },
         {
@@ -64,6 +60,13 @@ export const getMainMenu = (appWindow: AppWindow) => {
           label: 'Select next tab',
           click() {
             appWindow.webContents.send('select-next-tab');
+          },
+        },
+        {
+          accelerator: 'Ctrl+Space',
+          label: 'Toggle Overlay',
+          click() {
+            appWindow.webContents.send('toggle-overlay');
           },
         },
       ],

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -76,6 +76,26 @@ export const getMainMenu = (appWindow: AppWindow) => {
             appWindow.webContents.send('toggle-overlay');
           },
         },
+        {
+          accelerator: 'CmdOrCtrl+Left',
+          label: 'Go back',
+          click() {
+            const { selected } = appWindow.viewManager;
+            if (selected) {
+              selected.webContents.goBack();
+            }
+          },
+        },
+        {
+          accelerator: 'CmdOrCtrl+Right',
+          label: 'Go forward',
+          click() {
+            const { selected } = appWindow.viewManager;
+            if (selected) {
+              selected.webContents.goForward();
+            }
+          },
+        },
       ],
     },
   ]);

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -1,5 +1,6 @@
 import { AppWindow } from '../windows';
 import { Menu } from 'electron';
+import { defaultTabOptions } from '~/constants/tabs';
 
 export const getMainMenu = (appWindow: AppWindow) => {
   return Menu.buildFromTemplate([
@@ -35,10 +36,10 @@ export const getMainMenu = (appWindow: AppWindow) => {
           },
         },
         {
-          accelerator: 'CmdOrCtrl+F',
-          label: 'Find in page',
+          accelerator: 'CmdOrCtrl+T',
+          label: 'New tab',
           click() {
-            appWindow.webContents.send('find');
+            appWindow.viewManager.create(defaultTabOptions);
           },
         },
       ],

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -15,7 +15,7 @@ export const getMainMenu = (appWindow: AppWindow) => {
         { role: 'pasteandmatchstyle' },
         { role: 'delete' },
         { role: 'selectall' },
-        { role: 'quit' },
+        { role: 'quit', accelerator: 'CmdOrCtrl+Shift+Q' },
         {
           label: 'Reload',
           accelerator: 'CmdOrCtrl+R',
@@ -25,6 +25,13 @@ export const getMainMenu = (appWindow: AppWindow) => {
             } else {
               appWindow.viewManager.selected.webContents.reload();
             }
+          },
+        },
+        {
+          accelerator: 'CmdOrCtrl+F',
+          label: 'Find in page',
+          click() {
+            appWindow.webContents.send('find');
           },
         },
         {

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -42,6 +42,16 @@ export const getMainMenu = (appWindow: AppWindow) => {
             appWindow.viewManager.create(defaultTabOptions);
           },
         },
+        {
+          accelerator: 'CmdOrCtrl+W',
+          label: 'Close tab',
+          click() {
+            appWindow.webContents.send(
+              'remove-tab',
+              appWindow.viewManager.selectedId,
+            );
+          },
+        },
       ],
     },
   ]);

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -59,6 +59,13 @@ export const getMainMenu = (appWindow: AppWindow) => {
             appWindow.webContents.send('revert-closed-tab');
           },
         },
+        {
+          accelerator: 'CmdOrCtrl+Tab',
+          label: 'Select next tab',
+          click() {
+            appWindow.webContents.send('select-next-tab');
+          },
+        },
       ],
     },
   ]);

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -52,6 +52,13 @@ export const getMainMenu = (appWindow: AppWindow) => {
             );
           },
         },
+        {
+          accelerator: 'CmdOrCtrl+Shift+T',
+          label: 'Revert closed tab',
+          click() {
+            appWindow.webContents.send('revert-closed-tab');
+          },
+        },
       ],
     },
   ]);

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -49,6 +49,16 @@ export const getMainMenu = (appWindow: AppWindow) => {
           },
         },
         {
+          accelerator: 'CmdOrCtrl+F4',
+          label: 'Close tab',
+          click() {
+            appWindow.webContents.send(
+              'remove-tab',
+              appWindow.viewManager.selectedId,
+            );
+          },
+        },
+        {
           accelerator: 'CmdOrCtrl+Shift+T',
           label: 'Revert closed tab',
           click() {
@@ -94,6 +104,13 @@ export const getMainMenu = (appWindow: AppWindow) => {
             if (selected) {
               selected.webContents.goForward();
             }
+          },
+        },
+        {
+          accelerator: 'Ctrl+Shift+W',
+          label: 'Close current window',
+          click() {
+            appWindow.close();
           },
         },
       ],

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -87,6 +87,27 @@ export const getMainMenu = (appWindow: AppWindow) => {
           },
         },
         {
+          accelerator: 'Alt+F',
+          label: 'Toggle Overlay',
+          click() {
+            appWindow.webContents.send('toggle-overlay');
+          },
+        },
+        {
+          accelerator: 'Alt+E',
+          label: 'Toggle Overlay',
+          click() {
+            appWindow.webContents.send('toggle-overlay');
+          },
+        },
+        {
+          accelerator: 'F10+Enter',
+          label: 'Toggle Overlay',
+          click() {
+            appWindow.webContents.send('toggle-overlay');
+          },
+        },
+        {
           accelerator: 'CmdOrCtrl+Left',
           label: 'Go back',
           click() {

--- a/src/main/services/multrin.ts
+++ b/src/main/services/multrin.ts
@@ -85,7 +85,10 @@ export class Multrin {
     });
 
     mouseHooks.on('mouse-down', () => {
-      if (this.appWindow.isMinimized()) return;
+      if (this.appWindow.isMinimized() || this.appWindow.isFocused()) {
+        this.draggedWindow = null;
+        return;
+      }
 
       setTimeout(() => {
         if (this.appWindow.isFocused()) {
@@ -100,11 +103,12 @@ export class Multrin {
     });
 
     mouseHooks.on('mouse-move', async (e: any) => {
+      if (this.appWindow.isFocused()) return;
+
       if (
         this.draggedWindow &&
         this.selectedWindow &&
-        this.draggedWindow.id === this.selectedWindow.id &&
-        !this.appWindow.isFocused()
+        this.draggedWindow.id === this.selectedWindow.id
       ) {
         const bounds = this.selectedWindow.getBounds();
         const { lastBounds } = this.selectedWindow;

--- a/src/main/view-manager.ts
+++ b/src/main/view-manager.ts
@@ -1,4 +1,4 @@
-import { ipcMain, session, IpcMainEvent } from 'electron';
+import { ipcMain, session } from 'electron';
 import { TOOLBAR_HEIGHT } from '~/renderer/views/app/constants/design';
 import { appWindow, log } from '.';
 import { View } from './view';

--- a/src/renderer/views/app/components/Toolbar/Tab/index.tsx
+++ b/src/renderer/views/app/components/Toolbar/Tab/index.tsx
@@ -143,7 +143,7 @@ const onContextMenu = (tab: ITab) => () => {
       label: 'Revert closed tab',
       enabled: store.tabs.closedUrl !== '',
       click: () => {
-        store.tabs.addTab({ active: true, url: store.tabs.closedUrl });
+        store.tabs.revertClosed();
       },
     },
   ]);

--- a/src/renderer/views/app/constants/tabs.ts
+++ b/src/renderer/views/app/constants/tabs.ts
@@ -1,12 +1,5 @@
 import { Power2 } from 'gsap';
 
-export const NEWTAB_URL = 'about:blank';
-
-export const defaultTabOptions: chrome.tabs.CreateProperties = {
-  url: NEWTAB_URL,
-  active: true,
-};
-
 export const TAB_MAX_WIDTH = 200;
 export const TAB_MIN_WIDTH = 72;
 export const TAB_PINNED_WIDTH = 32;

--- a/src/renderer/views/app/models/tab.ts
+++ b/src/renderer/views/app/models/tab.ts
@@ -4,11 +4,7 @@ import { ipcRenderer } from 'electron';
 import Vibrant = require('node-vibrant');
 
 import store from '../store';
-import {
-  TABS_PADDING,
-  defaultTabOptions,
-  TAB_ANIMATION_DURATION,
-} from '../constants';
+import { TABS_PADDING, TAB_ANIMATION_DURATION } from '../constants';
 import { getColorBrightness, callViewMethod } from '~/utils';
 
 const isColorAcceptable = (color: string) => {
@@ -105,7 +101,7 @@ export class ITab {
   }
 
   constructor(
-    { active, url } = defaultTabOptions,
+    { active, url }: chrome.tabs.CreateProperties,
     id: number,
     tabGroupId: number,
     isWindow: boolean,

--- a/src/renderer/views/app/store/index.ts
+++ b/src/renderer/views/app/store/index.ts
@@ -121,6 +121,12 @@ export class Store {
       },
     );
 
+    ipcRenderer.on('toggle-overlay', () => {
+      if (!this.overlay.isNewTab) {
+        this.overlay.visible = !this.overlay.visible;
+      }
+    });
+
     ipcRenderer.on('find', () => {
       const tab = this.tabs.selectedTab;
       if (tab) {

--- a/src/renderer/views/app/store/tabs.ts
+++ b/src/renderer/views/app/store/tabs.ts
@@ -141,6 +141,20 @@ export class TabsStore {
       }
     });
 
+    ipcRenderer.on('select-next-tab', () => {
+      const { tabs } = store.tabGroups.currentGroup;
+      const i = tabs.indexOf(this.selectedTab);
+      const nextTab = tabs[i + 1];
+
+      if (!nextTab) {
+        if (tabs[0]) {
+          tabs[0].select();
+        }
+      } else {
+        nextTab.select();
+      }
+    });
+
     ipcRenderer.on(
       'update-tab-find-info',
       (e: any, tabId: number, data: any) => {

--- a/src/renderer/views/app/store/tabs.ts
+++ b/src/renderer/views/app/store/tabs.ts
@@ -150,6 +150,10 @@ export class TabsStore {
         }
       },
     );
+
+    ipcRenderer.on('revert-closed-tab', () => {
+      this.revertClosed();
+    });
   }
 
   public resetRearrangeTabsTimer() {
@@ -368,6 +372,10 @@ export class TabsStore {
       this.lastMouseX = e.pageX;
     }
   };
+
+  public revertClosed() {
+    this.addTab({ active: true, url: this.closedUrl });
+  }
 
   public animateProperty(
     property: string,

--- a/src/renderer/views/app/store/tabs.ts
+++ b/src/renderer/views/app/store/tabs.ts
@@ -7,7 +7,6 @@ import { ITab } from '../models';
 
 import {
   TAB_ANIMATION_DURATION,
-  defaultTabOptions,
   TABS_PADDING,
   TOOLBAR_HEIGHT,
   TAB_ANIMATION_EASING,
@@ -17,6 +16,7 @@ import HorizontalScrollbar from '~/renderer/components/HorizontalScrollbar';
 import store from '.';
 import { ipcRenderer } from 'electron';
 import { getColorBrightness } from '~/utils';
+import { defaultTabOptions } from '~/constants/tabs';
 
 export class TabsStore {
   @observable


### PR DESCRIPTION
This PR adds most of the keyboard shortcuts related to tabs as specified [here](https://support.google.com/chrome/answer/157179?hl=pl) and in #148

- [x] New tab - `ctrl` + `t`
- [x] Close tab - `ctrl` + `w`, `ctrl` + `f4`
- [x] Close current window - `ctrl` + `shift` + `w`
- [x] Quit wexond - `ctrl` + `shift` + `q`
- [x] Find - `ctrl` + `f`
- [x] Switch to next tab - `ctrl` + `tab`
- [x] Toggle Overlay - `alt` + `space` `ctrl` + `l`, `alt` + `f`, `alt` + `e`, `F10` + `enter`
- [x] Go back - `alt` + `arrow left`
- [x] Go forward - `alt` + `arrow right`
- [x] Close focused tab - `ctrl` + `w`
- [x] Reopen closed tab: `ctrl` + `shift` + `t`