### PR TITLE
chore: update @cliqz/adblocker to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wexond",
-  "version": "2.2.3",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -170,14 +170,30 @@
       }
     },
     "@cliqz/adblocker": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-0.12.0.tgz",
-      "integrity": "sha512-+CklJUQujKc6MpXCAVGHkvhcSD9UMrf7oge6fh7stDRUDuT6V3jXjYavL3//pOZ/KqzdyuXtcNDNtTqNvEakiQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-0.13.1.tgz",
+      "integrity": "sha512-ZaCzY7zDPUYMJEJwMHrpFCYbG/AQ9ekHeIPRT7RE51rQEDjK18+qAc+g9knj9Xq04ZwXh7atLcbIt/jjRo6YIg==",
       "dev": true,
       "requires": {
         "tldts-experimental": "^5.3.0",
         "tslib": "^1.10.0",
-        "tsmaz": "^1.2.2"
+        "tsmaz": "^1.3.0"
+      }
+    },
+    "@cliqz/adblocker-content": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-0.13.1.tgz",
+      "integrity": "sha512-JrBey7dFQ3XM/IyYqUhxX7FTFDPNRUgmfVy2mhektUlQdDFxS31AAZeWTo92/Ck8MPpii14Zb01DQOe3iNa/Ow==",
+      "dev": true
+    },
+    "@cliqz/adblocker-electron": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-electron/-/adblocker-electron-0.13.1.tgz",
+      "integrity": "sha512-xwOjCJd1HGcVKDm3iHGUcMw5BJ47XMf3YxCvN6xQxY51+OHlDWSDW/J5qV4Lw5/rl/V2I+2vNmGKbjqlfn6dcA==",
+      "dev": true,
+      "requires": {
+        "@cliqz/adblocker": "^0.13.1",
+        "@cliqz/adblocker-content": "^0.13.1"
       }
     },
     "@develar/schema-utils": {
@@ -621,6 +637,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
       "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw==",
       "dev": true
+    },
+    "@types/node-fetch": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.0.tgz",
+      "integrity": "sha512-TLFRywthBgL68auWj+ziWu+vnmmcHCDFC/sqCOQf1xTz4hRq8cu79z8CtHU9lncExGBsB8fXA4TiLDLt6xvMzw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/pretty-bytes": {
       "version": "5.2.0",
@@ -7799,6 +7824,11 @@
         "cheerio": "^1.0.0-rc.3"
       }
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "node-forge": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
@@ -11177,9 +11207,9 @@
       "dev": true
     },
     "tsmaz": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tsmaz/-/tsmaz-1.2.2.tgz",
-      "integrity": "sha512-eqet1z09AtigITA7RyTiehtqNSWdXYp58XSkf7fpcLatYZDE0NmC/EL4LnbI9VUpYZPeMuIGLhW6jSNSZo62jg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tsmaz/-/tsmaz-1.3.0.tgz",
+      "integrity": "sha512-vcU8dokp/QecvbTldQIE9Y4MD+ObU8VOpkwKCvhwhLv+yVdLMyjq7vTuc/haLLclRFRtMRj2z+qR7IjN+fnpiQ==",
       "dev": true
     },
     "tsutils": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "extensions": "node scripts/extensions.js"
   },
   "devDependencies": {
-    "@cliqz/adblocker": "0.12.0",
+    "@cliqz/adblocker-electron": "^0.13.1",
     "@types/axios": "0.14.0",
     "@types/chrome": "0.0.88",
     "@types/file-type": "^10.9.1",
@@ -42,6 +42,7 @@
     "@types/keytar": "^4.4.0",
     "@types/nedb": "1.8.8",
     "@types/node": "12.7.0",
+    "@types/node-fetch": "^2.5.0",
     "@types/pretty-bytes": "^5.2.0",
     "@types/react": "16.8.24",
     "@types/react-dom": "16.8.5",
@@ -91,6 +92,7 @@
     "extract-file-icon": "0.3.1",
     "keytar": "^5.0.0-beta.0",
     "mouse-hooks": "0.4.1",
+    "node-fetch": "^2.6.0",
     "node-vibrant": "3.2.0-alpha",
     "node-window-manager": "1.0.4"
   }

--- a/src/main/services/adblock.ts
+++ b/src/main/services/adblock.ts
@@ -1,120 +1,65 @@
 import { Session } from 'electron';
-import { existsSync, readFile, writeFile } from 'fs';
+import { existsSync, promises as fs } from 'fs';
 import { resolve } from 'path';
-import { windowsManager } from '..';
-import Axios from 'axios';
+import fetch from 'node-fetch';
 
-import { FiltersEngine, Request, RequestType } from '@cliqz/adblocker';
+import { windowsManager } from '..';
+import { ElectronBlocker, Request } from '@cliqz/adblocker-electron';
 import { getPath } from '~/utils';
 
-const lists: { [key: string]: string } = {
-  easylist: 'https://easylist.to/easylist/easylist.txt',
-  easyprivacy: 'https://easylist.to/easylist/easyprivacy.txt',
-
-  'plowe-0':
-    'https://pgl.yoyo.org/adservers/serverlist.php?hostformat=adblockplus&showintro=0&mimetype=plaintext',
-
-  'ublock-filters':
-    'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt',
-  'ublock-badware':
-    'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/badware.txt',
-  'ublock-privacy':
-    'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/privacy.txt',
-  'ublock-unbreak':
-    'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/unbreak.txt',
-  'ublock-abuse':
-    'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resource-abuse.txt',
-};
-
-export let engine: FiltersEngine;
+export let engine: ElectronBlocker;
 
 const loadFilters = async () => {
   const path = resolve(getPath('adblock/cache.dat'));
 
-  const downloadFilters = () => {
-    const ops = [];
+  const downloadFilters = async () => {
+    // Load lists to perform ads and tracking blocking:
+    //
+    //  - https://easylist.to/easylist/easylist.txt
+    //  - https://pgl.yoyo.org/adservers/serverlist.php?hostformat=adblockplus&showintro=1&mimetype=plaintext
+    //  - https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resource-abuse.txt
+    //  - https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/badware.txt
+    //  - https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt
+    //  - https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/unbreak.txt
+    //
+    //  - https://easylist.to/easylist/easyprivacy.txt
+    //  - https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/privacy.txt
+    engine = await ElectronBlocker.fromPrebuiltAdsAndTracking(fetch);
 
-    for (const key in lists) {
-      ops.push(Axios.get(lists[key]));
+    try {
+      await fs.writeFile(path, engine.serialize());
+    } catch (err) {
+      if (err) return console.error(err);
     }
-
-    Axios.all(ops).then(async res => {
-      let data = '';
-
-      for (const res1 of res) {
-        data += res1.data;
-      }
-
-      engine = FiltersEngine.parse(data);
-
-      const resources = (await Axios.get(
-        'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resources.txt',
-      )).data;
-
-      engine.updateResources(resources, `${resources.length}`);
-
-      writeFile(path, engine.serialize(), err => {
-        if (err) return console.error(err);
-      });
-    });
   };
 
   if (existsSync(path)) {
-    readFile(resolve(path), (err, buffer) => {
-      if (err) return console.error(err);
+    try {
+      const buffer = await fs.readFile(resolve(path));
 
       try {
-        engine = FiltersEngine.deserialize(buffer);
+        engine = ElectronBlocker.deserialize(buffer);
       } catch (e) {
-        downloadFilters();
+        return downloadFilters();
       }
-
-      /*const { networkFilters, cosmeticFilters } = parseFilters(
-        data,
-        engine.config,
-      );
-      engine.update({
-        newNetworkFilters: networkFilters,
-        newCosmeticFilters: cosmeticFilters,
-      });*/
-    });
+    } catch (err) {
+      return console.error(err);
+    }
   } else {
-    downloadFilters();
+    return downloadFilters();
   }
 };
 
 export const runAdblockService = (ses: Session) => {
-  const { webRequest } = ses;
+  const emitBlockedEvent = (request: Request) => {
+    for (const window of windowsManager.list) {
+      window.webContents.send(`blocked-ad-${request.tabId}`);
+    }
+  };
 
-  loadFilters();
-
-  webRequest.onBeforeRequest(
-    { urls: ['<all_urls>'] },
-    async (details: Electron.OnBeforeRequestDetails, callback) => {
-      if (engine && windowsManager.settings.object.shield) {
-        const { match, redirect } = engine.match(
-          Request.fromRawDetails({
-            type: details.resourceType as RequestType,
-            url: details.url,
-          }),
-        );
-
-        if (match || redirect) {
-          if (redirect) {
-            callback({ redirectURL: redirect.dataUrl });
-          } else {
-            callback({ cancel: true });
-          }
-
-          for (const window of windowsManager.list) {
-            window.webContents.send(`blocked-ad-${details.webContentsId}`);
-          }
-
-          return;
-        }
-      }
-
-      callback({ cancel: false });
-    },
-  );
+  loadFilters().then(() => {
+    engine.enableBlockingInSession(ses);
+    engine.on('request-blocked', emitBlockedEvent);
+    engine.on('request-redirected', emitBlockedEvent);
+  });
 };


### PR DESCRIPTION
Hi there,

Since the latest [`@cliqz/adblocker-electron`](https://www.npmjs.com/package/@cliqz/adblocker-electron) has been released and includes quite a few improvements for integration with Electron project, here is a proposed change to integrate latest developments in `Wexond`.

In particular, list fetching and updating is now a bit easier (abstracted away by `ElectronBlocker`), and so is the filtering of requests and injection of cosmetics filters.

Best,
Rémi