### PR TITLE
chore: update adblocker to avoid certificate expiry of yoyo list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,9 +170,9 @@
       }
     },
     "@cliqz/adblocker": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-0.13.1.tgz",
-      "integrity": "sha512-ZaCzY7zDPUYMJEJwMHrpFCYbG/AQ9ekHeIPRT7RE51rQEDjK18+qAc+g9knj9Xq04ZwXh7atLcbIt/jjRo6YIg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-0.13.2.tgz",
+      "integrity": "sha512-vz89xXdJRiDTksc/btTCoR6fD5EJJnCHzLadxjZuR3AhWFB5YUypKRfLNDOTitEdPtIpj6F3hxsduTlBdcRO3Q==",
       "dev": true,
       "requires": {
         "tldts-experimental": "^5.3.0",
@@ -181,19 +181,19 @@
       }
     },
     "@cliqz/adblocker-content": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-0.13.1.tgz",
-      "integrity": "sha512-JrBey7dFQ3XM/IyYqUhxX7FTFDPNRUgmfVy2mhektUlQdDFxS31AAZeWTo92/Ck8MPpii14Zb01DQOe3iNa/Ow==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-0.13.2.tgz",
+      "integrity": "sha512-WYFLlHB8qNDI6ypZo2rmwzkBp0zZydPpvhcbkJ5q2AuMmZbOI4A7Hx0m+5ybV/wQGifeZtzIKf/SMyPMybhWyA==",
       "dev": true
     },
     "@cliqz/adblocker-electron": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-electron/-/adblocker-electron-0.13.1.tgz",
-      "integrity": "sha512-xwOjCJd1HGcVKDm3iHGUcMw5BJ47XMf3YxCvN6xQxY51+OHlDWSDW/J5qV4Lw5/rl/V2I+2vNmGKbjqlfn6dcA==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-electron/-/adblocker-electron-0.13.2.tgz",
+      "integrity": "sha512-GQwD9iSKqhV75WIKregDauO2GrESm7yskjx9BpEjLNwcp8470/IMeAMl6EbC7Ecrxw+EyB1GQtWa9u+2sq+NLw==",
       "dev": true,
       "requires": {
-        "@cliqz/adblocker": "^0.13.1",
-        "@cliqz/adblocker-content": "^0.13.1"
+        "@cliqz/adblocker": "^0.13.2",
+        "@cliqz/adblocker-content": "^0.13.2"
       }
     },
     "@develar/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "extensions": "node scripts/extensions.js"
   },
   "devDependencies": {
-    "@cliqz/adblocker-electron": "^0.13.1",
+    "@cliqz/adblocker-electron": "^0.13.2",
     "@types/axios": "0.14.0",
     "@types/chrome": "0.0.88",
     "@types/file-type": "^10.9.1",


### PR DESCRIPTION
Hi again,

I noticed 45 minutes ago that the domain of one of the filters list providers expired (https://t.co/Zywkn1SMvx?amp=1); since this is one of the lists used in Wexond, I pushed a fix upstream which now gets this list from a mirror (which is hosted in the adblocker project directly). This should fix certificate errors raised during updating of the adblocker in Wexond. Hopefully no one was impacted yet.

Best,
Rémi