### PR TITLE
chore: update adblocker to fix issue with yoyo list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,9 +170,9 @@
       }
     },
     "@cliqz/adblocker": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-0.13.2.tgz",
-      "integrity": "sha512-vz89xXdJRiDTksc/btTCoR6fD5EJJnCHzLadxjZuR3AhWFB5YUypKRfLNDOTitEdPtIpj6F3hxsduTlBdcRO3Q==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-0.14.0.tgz",
+      "integrity": "sha512-+peKCkgp46LMOR2gm8uY2EeCmBctkNPJFSLaxBb3Xh81If22Z7ImttuHZiDrvHr4AuEiJUE2IWC4N2lL3QWx6g==",
       "dev": true,
       "requires": {
         "tldts-experimental": "^5.3.0",
@@ -181,19 +181,19 @@
       }
     },
     "@cliqz/adblocker-content": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-0.13.2.tgz",
-      "integrity": "sha512-WYFLlHB8qNDI6ypZo2rmwzkBp0zZydPpvhcbkJ5q2AuMmZbOI4A7Hx0m+5ybV/wQGifeZtzIKf/SMyPMybhWyA==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-0.14.0.tgz",
+      "integrity": "sha512-5x6hM0Jsikith8RdK11QXLgjfxTSkGWdutHruNBdOQkGxUfLebQ/+0mCmbrWHWgWxWqOfo5QOZmOY4q4xVhbiQ==",
       "dev": true
     },
     "@cliqz/adblocker-electron": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-electron/-/adblocker-electron-0.13.2.tgz",
-      "integrity": "sha512-GQwD9iSKqhV75WIKregDauO2GrESm7yskjx9BpEjLNwcp8470/IMeAMl6EbC7Ecrxw+EyB1GQtWa9u+2sq+NLw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-electron/-/adblocker-electron-0.14.0.tgz",
+      "integrity": "sha512-/TKIPD8iutMm2d8sIQvNA8bZiTfh+v0q5pdZcffcBrL7ENF8EK3yxb3EmpgfIpOun7E9Hskt2ch6JlXjJpY2jQ==",
       "dev": true,
       "requires": {
-        "@cliqz/adblocker": "^0.13.2",
-        "@cliqz/adblocker-content": "^0.13.2"
+        "@cliqz/adblocker": "^0.14.0",
+        "@cliqz/adblocker-content": "^0.14.0"
       }
     },
     "@develar/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "extensions": "node scripts/extensions.js"
   },
   "devDependencies": {
-    "@cliqz/adblocker-electron": "^0.13.2",
+    "@cliqz/adblocker-electron": "^0.14.0",
     "@types/axios": "0.14.0",
     "@types/chrome": "0.0.88",
     "@types/file-type": "^10.9.1",


### PR DESCRIPTION
Hey there,

I realized that I introduced a breaking change while preparing the lastest release of the adblocker. Version `0.13.2` depends upon a file hosted on the adblocker repository (this was a temporary fix until the certificate of the site hosting one of the filters list we use was renewed). This file has been removed so it might raise an exception when you try to initialize the adblocker (unless it's loaded from cache, which should work). This update should fix that.

I hope nothing broke on your side,
Best,
Rémi