### PR TITLE
Allow Wexond to be a default browser in Windows

### DIFF
--- a/src/main/windows-manager.ts
+++ b/src/main/windows-manager.ts
@@ -1,5 +1,5 @@
 import { AppWindow } from './windows';
-import { app, Menu, ipcMain } from 'electron';
+import { app, Menu, ipcMain, ipcRenderer } from 'electron';
 import { isAbsolute, extname } from 'path';
 import { existsSync } from 'fs';
 import { getMainMenu } from './menus/main';
@@ -7,6 +7,7 @@ import { SessionsManager } from './sessions-manager';
 import { runAutoUpdaterService } from './services';
 import { checkFiles } from '~/utils/files';
 import { Settings } from './models/settings';
+import { isURL, prefixHttp } from '~/utils';
 
 export class WindowsManager {
   public list: AppWindow[] = [];
@@ -40,6 +41,13 @@ export class WindowsManager {
           }
           return;
         }
+        else if (isURL(path)){
+          this.currentWindow.viewManager.create({
+            url: prefixHttp(path),
+            active: true
+        });
+        return;
+      }
 
         this.createWindow();
       });

--- a/static/installer.nsh
+++ b/static/installer.nsh
@@ -1,16 +1,35 @@
 !macro customInstall
   WriteRegStr SHCTX "SOFTWARE\RegisteredApplications" "Wexond" "Software\Clients\StartMenuInternet\Wexond\Capabilities"
-  WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond\Capabilities\StartMenu" "StartMenuInternet" "Wexond"
+
+  WriteRegStr SHCTX "SOFTWARE\Classes\Wexond" "" "Wexond HTML Document"
+  WriteRegStr SHCTX "SOFTWARE\Classes\Wexond\Application" "AppUserModelId" "Wexond"
+  WriteRegStr SHCTX "SOFTWARE\Classes\Wexond\Application" "ApplicationIcon" "$INSTDIR\Wexond.exe,0"
+  WriteRegStr SHCTX "SOFTWARE\Classes\Wexond\Application" "ApplicationName" "Wexond"
+  WriteRegStr SHCTX "SOFTWARE\Classes\Wexond\Application" "ApplicationCompany" "Wexond"      
+  WriteRegStr SHCTX "SOFTWARE\Classes\Wexond\Application" "ApplicationDescription" "A privacy-focused, extensible and beautiful web browser"      
+  WriteRegStr SHCTX "SOFTWARE\Classes\Wexond\DefaultIcon" "DefaultIcon" "$INSTDIR\Wexond.exe,0"
+  WriteRegStr SHCTX "SOFTWARE\Classes\Wexond\shell\open\command" "" '"$INSTDIR\Wexond.exe" "%1"'
+
+  WriteRegStr SHCTX "SOFTWARE\Classes\.htm\OpenWithProgIds" "Wexond" ""
+  WriteRegStr SHCTX "SOFTWARE\Classes\.html\OpenWithProgIds" "Wexond" ""
+
   WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond" "" "Wexond"
+  WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond\DefaultIcon" "" "$INSTDIR\Wexond.exe,0"
   WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond\Capabilities" "ApplicationDescription" "A privacy-focused, extensible and beautiful web browser"
   WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond\Capabilities" "ApplicationName" "Wexond"
+  WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond\Capabilities" "ApplicationIcon" "$INSTDIR\Wexond.exe,0"
+  WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond\Capabilities\FileAssociations" ".htm" "Wexond"
+  WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond\Capabilities\FileAssociations" ".html" "Wexond"
+  WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond\Capabilities\URLAssociations" "http" "Wexond"
+  WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond\Capabilities\URLAssociations" "https" "Wexond"
+  WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond\Capabilities\StartMenu" "StartMenuInternet" "Wexond"
+  
   WriteRegDWORD SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond\InstallInfo" "IconsVisible" 1
-  WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond\shell\open\command" "" "$0\Wexond.exe"
-  WriteRegStr HKCU "SOFTWARE\Classes\BraveBetaHTML\shell\open\command" "" '"$0\Wexond.exe" -- "%1"'
-  WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\BraveBeta\Capabilities\URLAssociations" "http" "Wexond"
+  
+  WriteRegStr SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond\shell\open\command" "" "$INSTDIR\Wexond.exe"
 !macroend
 !macro customUnInstall
-  DeleteRegKey HKCU "SOFTWARE\Classes\Wexond"
+  DeleteRegKey SHCTX "SOFTWARE\Classes\Wexond"
   DeleteRegKey SHCTX "SOFTWARE\Clients\StartMenuInternet\Wexond"
   DeleteRegValue SHCTX "SOFTWARE\RegisteredApplications" "Wexond"
 !macroend


### PR DESCRIPTION
Added handler for command line arg that is a URL
Added registry settings that allow Windows to recognize Wexond as a browser
