### PR TITLE
Fix for not being able to sign in to Google, among other sites.

### DIFF
--- a/src/main/view.ts
+++ b/src/main/view.ts
@@ -26,6 +26,7 @@ export class View extends BrowserView {
         additionalArguments: [`--window-id=${window.id}`],
         nativeWindowOpen: true,
         webSecurity: true,
+        javascript: true,
       },
     });
 

--- a/src/main/windows/app.ts
+++ b/src/main/windows/app.ts
@@ -41,6 +41,7 @@ export class AppWindow extends BrowserWindow {
         plugins: true,
         nodeIntegration: true,
         contextIsolation: false,
+        javascript: true,
       },
       icon: resolve(app.getAppPath(), 'static/app-icons/icon.png'),
     });


### PR DESCRIPTION
 JS being disabled was causing the "You're using a browser that Google doesn't recognize or that's set up in a way that we don't support."

https://github.com/wexond/desktop/issues/265