### PR TITLE
fix: User-Agent still too unique (Related to #341)

### DIFF
--- a/src/main/view.ts
+++ b/src/main/view.ts
@@ -36,8 +36,8 @@ export class View extends BrowserView {
     });
 
     this.webContents.userAgent = this.webContents.userAgent
-      .replace(/Wexond\\?.([^\s]+)/g, '')
-      .replace(/Electron\\?.([^\s]+)/g, '');
+      .replace(/ Wexond\\?.([^\s]+)/g, '')
+      .replace(/ Electron\\?.([^\s]+)/g, '');
 
     this.window = window;
     this.homeUrl = url;


### PR DESCRIPTION
As #341 had been closed, the User-Agent is not identifiable, right?
The google log-in doesn't show the old design anymore.. so everything's allright, isn't it?

Well, I thought that I can now go to the Qwant search engine without it telling me to change my user-agent.. but it did.
I looked up my user-agent:
`Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)  Chrome/78.0.3904.92  Safari/537.36`
It doesn't look suspicious at first sight. Here is wexond's old user-agent for comparison:
`Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Wexond/3.1.0 Chrome/76.0.3809.146 Electron/6.0.12 Safari/537.36)`

If you take a closer look however, you can see that the parts of the user agent where things were altered, there is an additional space. Because of those two spaces, wexond users can be seperated from all other users on the web.

With this push request applied, wexond users are harder to identify throughout the web.

**To Reproduce**
Go to [this site to show your user agent](https://developers.whatismybrowser.com/useragents/parse/?analyse-my-user-agent=yes#parse-useragent) or to [the Qwant search engine](https://qwant.com).

**Expected behavior**
The User-agent should be the same as Chrome 78's.
