### PR TITLE
feat: add a couple of more keyboard shortcuts

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -10,6 +10,9 @@
 | Open a new incognito window | Ctrl + Shift + N             |
 | Open a new tab              | Ctrl + T                     |
 | Select next tab             | Ctrl + Tab                   |
+| Select previous tab         | Ctrl + Shift + Tab           |
+| Select specific tab         | Ctrl + 1 to Ctrl + 8         |
+| Select the rightmost tab    | Ctrl + 9                     |
 | Go back                     | Alt + Left Arrow             |
 | Go forward                  | Alt + Right Arrow            |
 | Close selected tab          | Ctrl + W or Ctrl + F4        |
@@ -18,10 +21,13 @@
 
 ### Shortcuts for Wexond functions
 
-| Action                   | Shortcut                       |
-| ------------------------ | ------------------------------ |
-| Open Overlay             | Alt + F or Alt + E or Ctrl + L |
-| Open find in page dialog | Ctrl + F                       |
+| Action                                  | Shortcut                  |
+| --------------------------------------- | ------------------------- |
+| Open the menu                           | Alt + F or Alt + E        |
+| Focus the address bar                   | Ctrl + L or Alt + D or F6 |
+| Open find in page dialog                | Ctrl + F                  |
+| Open the Bookmarks Manager in a new tab | Ctrl + Shift + O          |
+| Open the History page in a new tab      | Ctrl + H                  |
 
 ### Shortcuts regarding websites
 

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -108,6 +108,16 @@ export const getMainMenu = (windowsManager: WindowsManager) => {
           },
         },
         {
+          accelerator: 'CmdOrCtrl+Shift+Tab',
+          label: 'Select next tab',
+          visible: false,
+          click() {
+            windowsManager.currentWindow.webContents.send(
+              'select-previous-tab',
+            );
+          },
+        },
+        {
           accelerator: 'Ctrl+Space',
           label: 'Toggle search',
           visible: false,

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -2,6 +2,7 @@ import { Menu, webContents } from 'electron';
 import { defaultTabOptions } from '~/constants/tabs';
 import { WindowsManager } from '../windows-manager';
 import { viewSource, saveAs, printPage } from './common-actions';
+import { WEBUI_BASE_URL, WEBUI_URL_SUFFIX } from '~/constants/files';
 
 export const getMainMenu = (windowsManager: WindowsManager) => {
   const template: any = [
@@ -55,6 +56,28 @@ export const getMainMenu = (windowsManager: WindowsManager) => {
         {
           role: 'quit',
           accelerator: 'CmdOrCtrl+Shift+Q',
+        },
+        {
+          accelerator: 'CmdOrCtrl+H',
+          label: 'History',
+          visible: false,
+          click() {
+            windowsManager.currentWindow.viewManager.create({
+              url: `${WEBUI_BASE_URL}history${WEBUI_URL_SUFFIX}`,
+              active: true,
+            });
+          },
+        },
+        {
+          accelerator: 'CmdOrCtrl+Shift+O',
+          label: 'Bookmarks',
+          visible: false,
+          click() {
+            windowsManager.currentWindow.viewManager.create({
+              url: `${WEBUI_BASE_URL}bookmarks${WEBUI_URL_SUFFIX}`,
+              active: true,
+            });
+          },
         },
         {
           label: 'Reload',

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -175,6 +175,22 @@ export const getMainMenu = (windowsManager: WindowsManager) => {
           },
         },
         {
+          accelerator: 'Alt+D',
+          label: 'Toggle search',
+          visible: false,
+          click() {
+            windowsManager.currentWindow.dialogs.searchDialog.show();
+          },
+        },
+        {
+          accelerator: 'F6',
+          label: 'Toggle search',
+          visible: false,
+          click() {
+            windowsManager.currentWindow.dialogs.searchDialog.show();
+          },
+        },
+        {
           accelerator: 'Alt+F',
           label: 'Toggle menu',
           visible: false,

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -4,7 +4,7 @@ import { WindowsManager } from '../windows-manager';
 import { viewSource, saveAs, printPage } from './common-actions';
 
 export const getMainMenu = (windowsManager: WindowsManager) => {
-  return Menu.buildFromTemplate([
+  const template: any = [
     {
       label: 'File',
       submenu: [
@@ -245,5 +245,21 @@ export const getMainMenu = (windowsManager: WindowsManager) => {
       ],
     },
     { role: 'editMenu' },
-  ]);
+  ];
+
+  for (let i = 1; i <= 9; i++) {
+    template[0].submenu.push({
+      accelerator: `CmdOrCtrl+${i}`,
+      label: 'Select tab index',
+      visible: false,
+      click() {
+        windowsManager.currentWindow.webContents.send(
+          'select-tab-index',
+          i - 1,
+        );
+      },
+    });
+  }
+
+  return Menu.buildFromTemplate(template);
 };

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -270,7 +270,7 @@ export const getMainMenu = (windowsManager: WindowsManager) => {
     { role: 'editMenu' },
   ];
 
-  for (let i = 1; i <= 9; i++) {
+  for (let i = 1; i <= 8; i++) {
     template[0].submenu.push({
       accelerator: `CmdOrCtrl+${i}`,
       label: 'Select tab index',
@@ -283,6 +283,15 @@ export const getMainMenu = (windowsManager: WindowsManager) => {
       },
     });
   }
+
+  template[0].submenu.push({
+    accelerator: `CmdOrCtrl+9`,
+    label: 'Select last tab',
+    visible: false,
+    click() {
+      windowsManager.currentWindow.webContents.send('select-last-tab');
+    },
+  });
 
   return Menu.buildFromTemplate(template);
 };

--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -108,8 +108,26 @@ export const getMainMenu = (windowsManager: WindowsManager) => {
           },
         },
         {
-          accelerator: 'CmdOrCtrl+Shift+Tab',
+          accelerator: 'CmdOrCtrl+PageDown',
           label: 'Select next tab',
+          visible: false,
+          click() {
+            windowsManager.currentWindow.webContents.send('select-next-tab');
+          },
+        },
+        {
+          accelerator: 'CmdOrCtrl+Shift+Tab',
+          label: 'Select previous tab',
+          visible: false,
+          click() {
+            windowsManager.currentWindow.webContents.send(
+              'select-previous-tab',
+            );
+          },
+        },
+        {
+          accelerator: 'CmdOrCtrl+PageUp',
+          label: 'Select previous tab',
           visible: false,
           click() {
             windowsManager.currentWindow.webContents.send(

--- a/src/renderer/views/app/store/tabs.ts
+++ b/src/renderer/views/app/store/tabs.ts
@@ -99,7 +99,11 @@ export class TabsStore {
 
     ipcRenderer.on('select-tab-index', (e, i) => {
       const tab = this.list[i];
+      if (tab) tab.select();
+    });
 
+    ipcRenderer.on('select-last-tab', () => {
+      const tab = this.list[this.list.length - 1];
       if (tab) tab.select();
     });
 

--- a/src/renderer/views/app/store/tabs.ts
+++ b/src/renderer/views/app/store/tabs.ts
@@ -97,6 +97,12 @@ export class TabsStore {
       }
     });
 
+    ipcRenderer.on('select-tab-index', (e, i) => {
+      const tab = this.list[i];
+
+      if (tab) tab.select();
+    });
+
     ipcRenderer.on('select-previous-tab', () => {
       const i = this.list.indexOf(this.selectedTab);
       const prevTab = this.list[i - 1];

--- a/src/renderer/views/app/store/tabs.ts
+++ b/src/renderer/views/app/store/tabs.ts
@@ -97,6 +97,19 @@ export class TabsStore {
       }
     });
 
+    ipcRenderer.on('select-previous-tab', () => {
+      const i = this.list.indexOf(this.selectedTab);
+      const prevTab = this.list[i - 1];
+
+      if (!prevTab) {
+        if (this.list[this.list.length - 1]) {
+          this.list[this.list.length - 1].select();
+        }
+      } else {
+        prevTab.select();
+      }
+    });
+
     ipcRenderer.on('remove-tab', (e, id: number) => {
       const tab = this.getTabById(id);
       if (tab) {
@@ -232,7 +245,7 @@ export class TabsStore {
     requestAnimationFrame(() => {
       tab.setLeft(
         Math.max(
-          ...this.list.map(function (item) {
+          ...this.list.map(function(item) {
             return item.left;
           }),
         ) + TAB_MAX_WIDTH,
@@ -387,7 +400,7 @@ export class TabsStore {
       if (
         callingTab.left < tabGroup.left ||
         callingTab.left + callingTab.width >=
-        tabGroup.left + tabGroup.width + 20
+          tabGroup.left + tabGroup.width + 20
       ) {
         callingTab.removeFromGroup();
         return;
@@ -492,9 +505,9 @@ export class TabsStore {
       if (
         newLeft + selectedTab.width >
         container.current.scrollLeft +
-        container.current.offsetWidth -
-        TABS_PADDING +
-        20
+          container.current.offsetWidth -
+          TABS_PADDING +
+          20
       ) {
         left =
           container.current.scrollLeft +


### PR DESCRIPTION
## New keyboard shortcuts:

### Shortcuts regarding tabs and windows

| Action                      | Shortcut                     |
| --------------------------- | ---------------------------- |
| Select previous tab         | Ctrl + Shift + Tab           |
| Select specific tab         | Ctrl + 1 to Ctrl + 8         |
| Select the rightmost tab    | Ctrl + 9                     |

### Shortcuts for Wexond functions

| Action                                  | Shortcut                  |
| --------------------------------------- | ------------------------- |
| Open the menu                           | Alt + F or Alt + E        |
| Focus the address bar                   | Ctrl + L or Alt + D or F6 |
| Open the Bookmarks Manager in a new tab | Ctrl + Shift + O          |
| Open the History page in a new tab      | Ctrl + H                  |