### PR TITLE
fix: web-contents-call without args

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,7 +31,7 @@ ipcMain.on('get-webcontents-id', e => {
 
 ipcMain.handle(
   `web-contents-call`,
-  async (e, { webContentsId, method, args }) => {
+  async (e, { webContentsId, method, args = [] }) => {
     const wc = webContents.fromId(webContentsId);
     const result = (wc as any)[method](...args);
 


### PR DESCRIPTION
Problem:
Mousebutton navigation did invoke web-contents-call without any args.
```
ipcRenderer.invoke(`web-contents-call`, {
    webContentsId: tabId,
    method: 'goBack',
  });
```

In this case the handler got as `args` `undefined` which then would wrongly calls `goBack(undefined)`.

This fix defaults args as `[]` so that functions without any args can be called.