### PR TITLE
fix: ignore NET_ERROR ABORTED

### DIFF
--- a/src/main/view.ts
+++ b/src/main/view.ts
@@ -155,7 +155,8 @@ export class View extends BrowserView {
     this.webContents.addListener(
       'did-fail-load',
       (e, errorCode, errorDescription, validatedURL, isMainFrame) => {
-        if (isMainFrame) {
+        //ignore -3 (ABORTED) - An operation was aborted (due to user action).
+        if (isMainFrame && errorCode !== -3) {
           this.errorURL = validatedURL;
 
           this.webContents.loadURL(`wexond-error://network-error/${errorCode}`);


### PR DESCRIPTION
This PR fixes problemes if the user makes multiple actions (like spam goBack, refresh etc.) that could result in an -3 (ABORTED) error.

https://cs.chromium.org/chromium/src/net/base/net_error_list.h?g=0&l=35

This error indicates a user abort action that does not need to be displayed as a network-error.

![](https://i.imgur.com/6AEuAFl.gif)