### PR TITLE
fix: new solution to view dialogs

### DIFF
--- a/src/main/dialogs/dialog.ts
+++ b/src/main/dialogs/dialog.ts
@@ -107,7 +107,7 @@ export class Dialog extends BrowserView {
 
   public hide(bringToTop = false) {
     if (bringToTop) {
-      // this.bringToTop();
+      this.bringToTop();
     }
 
     if (!this.visible) return;

--- a/src/main/dialogs/dialog.ts
+++ b/src/main/dialogs/dialog.ts
@@ -52,7 +52,7 @@ export class Dialog extends BrowserView {
     this.name = name;
 
     ipcMain.on(`hide-${this.webContents.id}`, () => {
-      this.hide();
+      this.hide(false, false);
     });
 
     if (process.env.NODE_ENV === 'development') {
@@ -82,7 +82,6 @@ export class Dialog extends BrowserView {
 
   public toggle() {
     if (!this.visible) this.show();
-    else this.hide();
   }
 
   public show(focus = true) {
@@ -105,7 +104,7 @@ export class Dialog extends BrowserView {
     this.webContents.send('visible', false);
   }
 
-  public hide(bringToTop = false, cb: () => void = null) {
+  public hide(bringToTop = false, hideVisually = true) {
     if (bringToTop) {
       this.bringToTop();
     }
@@ -114,16 +113,14 @@ export class Dialog extends BrowserView {
 
     clearTimeout(this.timeout);
 
-    this.hideVisually();
+    if (hideVisually) this.hideVisually();
 
     if (this.hideTimeout) {
       this.timeout = setTimeout(() => {
         this.appWindow.removeBrowserView(this);
-        if (cb) cb();
       }, this.hideTimeout);
     } else {
       this.appWindow.removeBrowserView(this);
-      if (cb) cb();
     }
 
     this.visible = false;

--- a/src/main/dialogs/dialog.ts
+++ b/src/main/dialogs/dialog.ts
@@ -86,7 +86,10 @@ export class Dialog extends BrowserView {
   }
 
   public show(focus = true) {
-    if (this.visible) return;
+    if (this.visible) {
+      if (focus) this.webContents.focus();
+      return;
+    }
 
     this.visible = true;
 

--- a/src/main/dialogs/dialog.ts
+++ b/src/main/dialogs/dialog.ts
@@ -42,7 +42,6 @@ export class Dialog extends BrowserView {
       webPreferences: {
         nodeIntegration: true,
         contextIsolation: false,
-        affinity: 'dialog',
         ...webPreferences,
       },
     });
@@ -93,35 +92,19 @@ export class Dialog extends BrowserView {
 
     clearTimeout(this.timeout);
 
-    this.bringToTop();
-
-    if (process.platform === 'darwin') {
-      setTimeout(() => {
-        if (focus) this.webContents.focus();
-      });
-    } else {
-      if (focus) this.webContents.focus();
-    }
-
+    this.appWindow.addBrowserView(this);
     this.rearrange();
+
+    if (focus) this.webContents.focus();
   }
 
   public hideVisually() {
     this.webContents.send('visible', false);
   }
 
-  private _hide() {
-    this.setBounds({
-      height: this.bounds.height,
-      width: 1,
-      x: 0,
-      y: -this.bounds.height + 1,
-    });
-  }
-
   public hide(bringToTop = false) {
     if (bringToTop) {
-      this.bringToTop();
+      // this.bringToTop();
     }
 
     if (!this.visible) return;
@@ -129,16 +112,19 @@ export class Dialog extends BrowserView {
     clearTimeout(this.timeout);
 
     if (this.hideTimeout) {
-      this.timeout = setTimeout(() => this._hide(), this.hideTimeout);
+      this.timeout = setTimeout(
+        () => this.appWindow.removeBrowserView(this),
+        this.hideTimeout,
+      );
     } else {
-      this._hide();
+      this.appWindow.removeBrowserView(this);
     }
 
     this.visible = false;
 
     this.hideVisually();
 
-    this.appWindow.fixDragging();
+    // this.appWindow.fixDragging();
   }
 
   public bringToTop() {

--- a/src/main/dialogs/dialog.ts
+++ b/src/main/dialogs/dialog.ts
@@ -86,14 +86,14 @@ export class Dialog extends BrowserView {
   }
 
   public show(focus = true) {
+    clearTimeout(this.timeout);
+
     if (this.visible) {
       if (focus) this.webContents.focus();
       return;
     }
 
     this.visible = true;
-
-    clearTimeout(this.timeout);
 
     this.appWindow.addBrowserView(this);
     this.rearrange();
@@ -105,7 +105,7 @@ export class Dialog extends BrowserView {
     this.webContents.send('visible', false);
   }
 
-  public hide(bringToTop = false) {
+  public hide(bringToTop = false, cb: () => void = null) {
     if (bringToTop) {
       this.bringToTop();
     }
@@ -114,18 +114,19 @@ export class Dialog extends BrowserView {
 
     clearTimeout(this.timeout);
 
+    this.hideVisually();
+
     if (this.hideTimeout) {
-      this.timeout = setTimeout(
-        () => this.appWindow.removeBrowserView(this),
-        this.hideTimeout,
-      );
+      this.timeout = setTimeout(() => {
+        this.appWindow.removeBrowserView(this);
+        if (cb) cb();
+      }, this.hideTimeout);
     } else {
       this.appWindow.removeBrowserView(this);
+      if (cb) cb();
     }
 
     this.visible = false;
-
-    this.hideVisually();
 
     // this.appWindow.fixDragging();
   }

--- a/src/main/dialogs/search.ts
+++ b/src/main/dialogs/search.ts
@@ -94,8 +94,8 @@ export class SearchDialog extends Dialog {
     });
   }
 
-  public hide(bringToTop = false, cb: () => void = null) {
-    super.hide(bringToTop, cb);
+  public hide(bringToTop = false) {
+    super.hide(bringToTop);
     this.queueShow = false;
   }
 }

--- a/src/main/dialogs/search.ts
+++ b/src/main/dialogs/search.ts
@@ -40,9 +40,11 @@ export class SearchDialog extends Dialog {
     });
 
     ipcMain.handle(`is-newtab-${this.webContents.id}`, () => {
-      return appWindow.viewManager.selected.webContents
-        .getURL()
-        .startsWith(NEWTAB_URL);
+      return appWindow.viewManager.selected
+        ? appWindow.viewManager.selected.webContents
+            .getURL()
+            .startsWith(NEWTAB_URL)
+        : false;
     });
   }
 

--- a/src/main/dialogs/search.ts
+++ b/src/main/dialogs/search.ts
@@ -92,8 +92,8 @@ export class SearchDialog extends Dialog {
     });
   }
 
-  public hide() {
-    super.hide();
+  public hide(bringToTop = false, cb: () => void = null) {
+    super.hide(bringToTop, cb);
     this.queueShow = false;
   }
 }

--- a/src/main/dialogs/search.ts
+++ b/src/main/dialogs/search.ts
@@ -1,6 +1,7 @@
 import { AppWindow } from '../windows';
 import { ipcMain } from 'electron';
 import { Dialog } from '.';
+import { NEWTAB_URL } from '~/constants/tabs';
 
 const WIDTH = 800;
 const HEIGHT = 56;
@@ -36,6 +37,12 @@ export class SearchDialog extends Dialog {
 
     ipcMain.on(`can-show-${this.webContents.id}`, () => {
       if (this.queueShow) this.show();
+    });
+
+    ipcMain.handle(`is-newtab-${this.webContents.id}`, () => {
+      return appWindow.viewManager.selected.webContents
+        .getURL()
+        .startsWith(NEWTAB_URL);
     });
   }
 

--- a/src/main/services/messaging.ts
+++ b/src/main/services/messaging.ts
@@ -54,7 +54,7 @@ export const runMessagingService = (appWindow: AppWindow) => {
   });
 
   ipcMain.on(`search-show-${id}`, e => {
-    appWindow.dialogs.searchDialog.toggle();
+    appWindow.dialogs.searchDialog.show();
   });
 
   ipcMain.on(`show-tab-preview-${id}`, (e, tab) => {

--- a/src/main/view-manager.ts
+++ b/src/main/view-manager.ts
@@ -125,8 +125,9 @@ export class ViewManager {
     this.window.removeBrowserView(selected);
     this.window.addBrowserView(view);
 
-    // this.window.dialogs.previewDialog.bringToTop();
-    this.window.dialogs.previewDialog.hideVisually();
+    if (this.window.dialogs.previewDialog.visible) {
+      this.window.dialogs.previewDialog.hide(true);
+    }
 
     if (this.incognito) {
       windowsManager.sessionsManager.extensionsIncognito.activeTab = id;
@@ -143,8 +144,8 @@ export class ViewManager {
 
     if (view.webContents.getURL().startsWith(NEWTAB_URL)) {
       this.window.dialogs.searchDialog.show();
-    } else {
-      this.window.dialogs.searchDialog.hideVisually();
+    } else if (this.window.dialogs.searchDialog.visible) {
+      this.window.dialogs.searchDialog.hide();
     }
 
     this.fixBounds();

--- a/src/main/view-manager.ts
+++ b/src/main/view-manager.ts
@@ -4,6 +4,7 @@ import { View } from './view';
 import { AppWindow } from './windows';
 import { WEBUI_BASE_URL } from '~/constants/files';
 import { windowsManager } from '.';
+import { NEWTAB_URL } from '~/constants/tabs';
 
 export class ViewManager {
   public views = new Map<number, View>();
@@ -124,9 +125,8 @@ export class ViewManager {
     this.window.removeBrowserView(selected);
     this.window.addBrowserView(view);
 
-    this.window.dialogs.searchDialog.hideVisually();
+    // this.window.dialogs.previewDialog.bringToTop();
     this.window.dialogs.previewDialog.hideVisually();
-    this.window.dialogs.tabGroupDialog.hideVisually();
 
     if (this.incognito) {
       windowsManager.sessionsManager.extensionsIncognito.activeTab = id;
@@ -136,6 +136,16 @@ export class ViewManager {
 
     // Also fixes switching tabs with Ctrl + Tab
     view.webContents.focus();
+
+    if (this.window.dialogs.searchDialog.visible) {
+      this.window.dialogs.searchDialog.bringToTop();
+    }
+
+    if (view.webContents.getURL().startsWith(NEWTAB_URL)) {
+      this.window.dialogs.searchDialog.show();
+    } else {
+      this.window.dialogs.searchDialog.hideVisually();
+    }
 
     this.fixBounds();
   }

--- a/src/main/view-manager.ts
+++ b/src/main/view-manager.ts
@@ -122,6 +122,12 @@ export class ViewManager {
     view.updateWindowTitle();
     view.updateBookmark();
 
+    if (this.incognito) {
+      windowsManager.sessionsManager.extensionsIncognito.activeTab = id;
+    } else {
+      windowsManager.sessionsManager.extensions.activeTab = id;
+    }
+
     this.window.removeBrowserView(selected);
     this.window.addBrowserView(view);
 
@@ -129,23 +135,14 @@ export class ViewManager {
       this.window.dialogs.previewDialog.hide(true);
     }
 
-    if (this.incognito) {
-      windowsManager.sessionsManager.extensionsIncognito.activeTab = id;
-    } else {
-      windowsManager.sessionsManager.extensions.activeTab = id;
-    }
-
     // Also fixes switching tabs with Ctrl + Tab
     view.webContents.focus();
 
-    if (this.window.dialogs.searchDialog.visible) {
-      this.window.dialogs.searchDialog.bringToTop();
-    }
-
     if (view.webContents.getURL().startsWith(NEWTAB_URL)) {
+      this.window.dialogs.searchDialog.bringToTop();
       this.window.dialogs.searchDialog.show();
     } else if (this.window.dialogs.searchDialog.visible) {
-      this.window.dialogs.searchDialog.hide();
+      this.window.dialogs.searchDialog.hide(true);
     }
 
     this.fixBounds();

--- a/src/main/view.ts
+++ b/src/main/view.ts
@@ -6,6 +6,7 @@ import storage from './services/storage';
 import Vibrant = require('node-vibrant');
 import { IHistoryItem, IBookmark } from '~/interfaces';
 import { WEBUI_BASE_URL } from '~/constants/files';
+import { NEWTAB_URL } from '~/constants/tabs';
 
 export class View extends BrowserView {
   public title = '';
@@ -232,6 +233,7 @@ export class View extends BrowserView {
       width: true,
       height: true,
     } as any);
+
     this.webContents.loadURL(url);
   }
 
@@ -300,6 +302,12 @@ export class View extends BrowserView {
       `view-url-updated-${this.webContents.id}`,
       url,
     );
+
+    if (url.startsWith(NEWTAB_URL)) {
+      this.window.dialogs.searchDialog.show();
+    } else {
+      this.window.dialogs.searchDialog.hide();
+    }
 
     this.updateData();
     this.updateCredentials();

--- a/src/models/dialog-store.ts
+++ b/src/models/dialog-store.ts
@@ -20,6 +20,7 @@ export class DialogStore {
     if (hideOnBlur) {
       window.addEventListener('blur', () => {
         if (this.visible) {
+          this.visible = false;
           setTimeout(() => {
             this.hide();
           });

--- a/src/models/dialog-store.ts
+++ b/src/models/dialog-store.ts
@@ -19,12 +19,7 @@ export class DialogStore {
   public constructor({ hideOnBlur } = { hideOnBlur: true }) {
     if (hideOnBlur) {
       window.addEventListener('blur', () => {
-        if (this.visible) {
-          this.visible = false;
-          setTimeout(() => {
-            this.hide();
-          });
-        }
+        this.hide();
       });
     }
 
@@ -44,6 +39,11 @@ export class DialogStore {
   }
 
   public hide() {
-    ipcRenderer.send(`hide-${this.id}`);
+    if (this.visible) {
+      this.visible = false;
+      setTimeout(() => {
+        ipcRenderer.send(`hide-${this.id}`);
+      }, 10);
+    }
   }
 }

--- a/src/renderer/mixins/dialogs.ts
+++ b/src/renderer/mixins/dialogs.ts
@@ -11,9 +11,17 @@ export const DialogStyle = styled.div`
   border-radius: 6px;
   overflow: hidden;
   position: relative;
-  transition: ${DIALOG_TRANSITION};
 
-  ${({ visible, theme }: { visible: boolean; theme?: ITheme }) => css`
+  ${({
+  visible,
+  theme,
+  hideTransition,
+}: {
+  visible: boolean;
+  theme?: ITheme;
+  hideTransition?: boolean;
+}) => css`
+    transition: ${!visible && !hideTransition ? 'none' : DIALOG_TRANSITION};
     opacity: ${visible ? 1 : 0};
     transform: translateY(${visible ? 0 : -10}px);
     background-color: ${theme['dialog.backgroundColor']};

--- a/src/renderer/views/app/components/Toolbar/Tab/index.tsx
+++ b/src/renderer/views/app/components/Toolbar/Tab/index.tsx
@@ -30,13 +30,12 @@ const onCloseMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
 const onMouseDown = (tab: ITab) => (e: React.MouseEvent<HTMLDivElement>) => {
   const { pageX, button } = e;
 
-  ipcRenderer.send(`hide-tab-preview-${store.windowId}`);
-
   if (button !== 0) return;
 
   if (!tab.isSelected) {
     tab.select();
   } else {
+    ipcRenderer.send(`hide-tab-preview-${store.windowId}`);
     store.canToggleMenu = true;
   }
 

--- a/src/renderer/views/app/models/tab.ts
+++ b/src/renderer/views/app/models/tab.ts
@@ -251,10 +251,6 @@ export class ITab {
       ipcRenderer.send(`update-find-info-${store.windowId}`, this.id, {
         ...this.findInfo,
       });
-
-      if (this.url.startsWith(NEWTAB_URL)) {
-        ipcRenderer.send(`search-show-${store.windowId}`);
-      }
     }
   }
 

--- a/src/renderer/views/menu/store/index.ts
+++ b/src/renderer/views/menu/store/index.ts
@@ -13,6 +13,7 @@ export class Store extends DialogStore {
     super();
     ipcRenderer.on('visible', async (e, flag) => {
       this.visible = flag;
+
       if (flag) {
         if (remote.getCurrentWindow()) {
           this.alwaysOnTop = remote.getCurrentWindow().isAlwaysOnTop();

--- a/src/renderer/views/menu/store/index.ts
+++ b/src/renderer/views/menu/store/index.ts
@@ -13,8 +13,13 @@ export class Store extends DialogStore {
     super();
     ipcRenderer.on('visible', async (e, flag) => {
       this.visible = flag;
-      this.alwaysOnTop = remote.getCurrentWindow().isAlwaysOnTop();
-      this.updateAvailable = await ipcRenderer.invoke('is-update-available');
+      if (flag) {
+        if (remote.getCurrentWindow()) {
+          this.alwaysOnTop = remote.getCurrentWindow().isAlwaysOnTop();
+        }
+
+        this.updateAvailable = await ipcRenderer.invoke('is-update-available');
+      }
     });
 
     ipcRenderer.on('update-available', () => {

--- a/src/renderer/views/search/components/App/index.tsx
+++ b/src/renderer/views/search/components/App/index.tsx
@@ -146,7 +146,7 @@ export const App = hot(
 
     return (
       <ThemeProvider theme={{ ...store.theme }}>
-        <StyledApp visible={store.visible}>
+        <StyledApp hideTransition visible={store.visible}>
           <GlobalStyle />
           <SearchBox>
             <CurrentIcon

--- a/src/renderer/views/search/store/index.ts
+++ b/src/renderer/views/search/store/index.ts
@@ -71,12 +71,22 @@ export class Store extends DialogStore {
   public tabId = 1;
 
   public constructor() {
-    super();
+    super({
+      hideOnBlur: false,
+    });
 
-    ipcRenderer.on('visible', (e, flag, tab) => {
-      this.visible = flag;
+    window.addEventListener('blur', async () => {
+      if (this.visible && !(await ipcRenderer.invoke(`is-newtab-${this.id}`))) {
+        this.visible = false;
+        setTimeout(() => {
+          this.hide();
+        });
+      }
+    });
 
+    ipcRenderer.on('visible', async (e, flag, tab) => {
       if (flag) {
+        this.visible = flag;
         this.tabs = [];
         this.suggestions.list = [];
         this.tabId = tab.id;
@@ -87,6 +97,8 @@ export class Store extends DialogStore {
         }
 
         this.inputRef.current.focus();
+      } else if (!(await ipcRenderer.invoke(`is-newtab-${this.id}`))) {
+        this.visible = flag;
       }
     });
 


### PR DESCRIPTION
Instead of moving a dialog out of window bounds to preserve animations, which is buggy on macOS, it just uses `removeBrowserView` and `addBrowserView` for hiding and showing. This PR also introduces a sticky search box on new tab page.