### PR TITLE
fix macos traffic light spacing

### DIFF
--- a/src/renderer/views/app/components/NavigationButtons/index.tsx
+++ b/src/renderer/views/app/components/NavigationButtons/index.tsx
@@ -37,7 +37,7 @@ export const NavigationButtons = observer(() => {
   }
 
   return (
-    <StyledContainer isFullscreen={store.isFullscreen}>
+    <StyledContainer>
       <ToolbarButton
         disabled={!store.navigationState.canGoBack}
         size={20}

--- a/src/renderer/views/app/components/NavigationButtons/style.ts
+++ b/src/renderer/views/app/components/NavigationButtons/style.ts
@@ -1,10 +1,6 @@
-import styled, { css } from 'styled-components';
-import { platform } from 'os';
+import styled from 'styled-components';
 
 export const StyledContainer = styled.div`
   display: flex;
   -webkit-app-region: no-drag;
-  ${({ isFullscreen }: { isFullscreen: boolean }) => css`
-    margin-left: ${platform() === 'darwin' && !isFullscreen ? 68 : 0}px;
-  `};
 `;

--- a/src/renderer/views/app/components/Tabbar/index.tsx
+++ b/src/renderer/views/app/components/Tabbar/index.tsx
@@ -53,7 +53,7 @@ export const TabGroups = observer(() => {
 
 export const Tabbar = observer(() => {
   return (
-    <StyledTabbar>
+    <StyledTabbar isFullscreen={store.isFullscreen}>
       <TabsContainer
         onMouseEnter={onMouseEnter}
         onMouseLeave={onTabsMouseLeave}

--- a/src/renderer/views/app/components/Tabbar/style.ts
+++ b/src/renderer/views/app/components/Tabbar/style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { platform } from 'os';
 
 import { ToolbarButton } from '../ToolbarButton';
 import {
@@ -16,6 +17,9 @@ export const StyledTabbar = styled.div`
   margin-left: 4px;
   margin-right: 32px;
   display: flex;
+  ${({ isFullscreen }: { isFullscreen: boolean }) => css`
+    margin-left: ${platform() === 'darwin' && !isFullscreen ? 78 : 0}px;
+  `};
 `;
 
 /* &:hover {


### PR DESCRIPTION
In the upstream version the spacing for the traffic light buttons on macOS are next to the navigation buttons which now sit below the tabs. This causes the button to appear over the first tab, obscuring it.
This PR moves the margin from the toolbar container to the tabbar container