### PR TITLE
Make zooming behave more like chromium / improve UX

### DIFF
--- a/src/main/view-manager.ts
+++ b/src/main/view-manager.ts
@@ -200,7 +200,7 @@ export class ViewManager {
 
     view.updateNavigationState();
 
-    this.emitZoomUpdate();
+    this.emitZoomUpdate(false);
   }
 
   public fixBounds() {
@@ -232,13 +232,14 @@ export class ViewManager {
     }
   }
 
-  public emitZoomUpdate() {
+  public emitZoomUpdate(showDialog: boolean = true) {
     this.zoomUpdateSubscribers.forEach((e) =>
       e.send('zoom-factor-updated', this.selected.webContents.zoomFactor),
     );
     this.window.webContents.send(
       'zoom-factor-updated',
       this.selected.webContents.zoomFactor,
+      showDialog,
     );
   }
 }

--- a/src/renderer/views/app/components/Toolbar/index.tsx
+++ b/src/renderer/views/app/components/Toolbar/index.tsx
@@ -98,9 +98,9 @@ ipcRenderer.on('show-menu-dialog', () => {
   showMenuDialog();
 });
 
-ipcRenderer.on('zoom-factor-updated', (e, zoomFactor) => {
+ipcRenderer.on('zoom-factor-updated', (e, zoomFactor, showDialog) => {
   store.zoomFactor = zoomFactor;
-  if(!store.dialogsVisibility['zoom']) {
+  if (!store.dialogsVisibility['zoom'] && showDialog) {
     showZoomDialog();
   }
 });

--- a/src/renderer/views/app/components/Toolbar/index.tsx
+++ b/src/renderer/views/app/components/Toolbar/index.tsx
@@ -350,11 +350,11 @@ export const Toolbar = observer(() => {
         {hasCredentials && (
           <ToolbarButton icon={ICON_KEY} size={16} onClick={onKeyClick} />
         )}
-        {store.zoomFactor != 1 && (
+        {(store.dialogsVisibility['zoom'] || store.zoomFactor !== 1) && (
           <ToolbarButton
             divRef={(r) => (zoomRef = r)}
             toggled={store.dialogsVisibility['zoom']}
-            icon={store.zoomFactor > 1 ? ICON_MAGNIFY_PLUS : ICON_MAGNIFY_MINUS}
+            icon={store.zoomFactor >= 1 ? ICON_MAGNIFY_PLUS : ICON_MAGNIFY_MINUS}
             size={18}
             dense
             onMouseDown={onZoomClick}


### PR DESCRIPTION
This pull request changes two things:
1. When crossing over the 100% step while zooming, the zoom icon won't disappear for a short amount of time / it waits until the dialog closes
**Before**:
![zooming-before](https://user-images.githubusercontent.com/14961554/80257605-9bbd5080-8681-11ea-8faa-8e732365a2ad.gif)
**After**:
![zooming-after](https://user-images.githubusercontent.com/14961554/80257612-a0820480-8681-11ea-8526-4d8d21e78d74.gif)

2. The zoom dialog won't appear anymore when switching to a tab with active zoom
**Before**:
![tabswitch-before](https://user-images.githubusercontent.com/14961554/80257633-a7a91280-8681-11ea-990b-2177aab78a7b.gif)
**After**:
![tabswitch-after](https://user-images.githubusercontent.com/14961554/80257638-ac6dc680-8681-11ea-8eb3-7d526f175790.gif)
