### PR TITLE
Add outline to selected tabs in groups

### DIFF
--- a/src/renderer/views/app/components/Tab/index.tsx
+++ b/src/renderer/views/app/components/Tab/index.tsx
@@ -295,6 +295,9 @@ export default observer(({ tab }: { tab: ITab }) => {
             : tab.isHovered
               ? defaultHoverColor
               : defaultColor,
+          borderColor: (tab.isSelected && tab.tabGroupId != undefined)
+            ? tab.tabGroup.color
+            : 'transparent',
         }}
       >
         <Content tab={tab} />

--- a/src/renderer/views/app/components/Tab/style.ts
+++ b/src/renderer/views/app/components/Tab/style.ts
@@ -167,6 +167,8 @@ export const TabContainer = styled.div`
   display: flex;
   backface-visibility: hidden;
   transition: 0.1s background-color;
+  border-bottom: transparent !important;
+  border: 2px solid;
 
   ${({ pinned }: TabContainerProps) => css`
     max-width: ${pinned ? `${TAB_PINNED_WIDTH}px` : '100%'};


### PR DESCRIPTION
This pull request adds an outline to selected tabs in groups
Closes #439 
![tab-outline](https://user-images.githubusercontent.com/14961554/80290571-4f881400-8746-11ea-98c6-e4a77c7651ec.gif)
