### PR TITLE
fix(extensions): get window.close to work in popup

### DIFF
--- a/src/preloads/popup-preload.ts
+++ b/src/preloads/popup-preload.ts
@@ -21,6 +21,10 @@ window.addEventListener('load', () => {
   resizeObserver.observe(document.body);
 });
 
-window.addEventListener('blur', () => {
+const close = () => {
   ipcRenderer.sendToHost('webview-blur');
-});
+};
+
+window.addEventListener('blur', close);
+
+window.close = close;


### PR DESCRIPTION
Notes: Fixed `window.close` in extension popup not doing anything.