### PR TITLE
fix: remove tab from map on destroy

### DIFF
--- a/src/main/view-manager.ts
+++ b/src/main/view-manager.ts
@@ -244,6 +244,8 @@ export class ViewManager {
   public destroy(id: number) {
     const view = this.views.get(id);
 
+    this.views.delete(id);
+
     if (view && !view.browserView.isDestroyed()) {
       this.window.win.removeBrowserView(view.browserView);
       view.destroy();


### PR DESCRIPTION
Closes #453 

Notes: Fixed invalid tabs count in the close warning.