### PR TITLE
fix: dialogs rearranging on window resize

### DIFF
--- a/src/main/dialogs/add-bookmark.ts
+++ b/src/main/dialogs/add-bookmark.ts
@@ -38,7 +38,10 @@ export const showAddBookmarkDialog = (
       x: x - 366 + DIALOG_MARGIN,
       y: y - DIALOG_MARGIN_TOP,
     }),
+    onWindowBoundsUpdate: () => dialog.hide(),
   });
+
+  if (!dialog) return;
 
   dialog.on('loaded', (e) => {
     e.reply('data', data);

--- a/src/main/dialogs/downloads.ts
+++ b/src/main/dialogs/downloads.ts
@@ -34,6 +34,7 @@ export const showDownloadsDialog = (
         height,
       };
     },
+    onWindowBoundsUpdate: () => dialog.hide(),
   });
 
   if (!dialog) return;

--- a/src/main/dialogs/extension-popup.ts
+++ b/src/main/dialogs/extension-popup.ts
@@ -25,6 +25,7 @@ export const showExtensionDialog = (
         width: Math.min(1024, width),
       };
     },
+    onWindowBoundsUpdate: () => dialog.hide(),
   });
 
   if (!dialog) return;

--- a/src/main/dialogs/find.ts
+++ b/src/main/dialogs/find.ts
@@ -3,20 +3,22 @@ import { BrowserWindow } from 'electron';
 import { Application } from '../application';
 
 export const showFindDialog = (browserWindow: BrowserWindow) => {
-  const { width } = browserWindow.getContentBounds();
   const appWindow = Application.instance.windows.fromBrowserWindow(
     browserWindow,
   );
 
-  Application.instance.dialogs.show({
+  const dialog = Application.instance.dialogs.show({
     name: 'find',
     browserWindow,
-    getBounds: () => ({
-      width: 416,
-      height: 70,
-      x: width - 416,
-      y: VIEW_Y_OFFSET,
-    }),
+    getBounds: () => {
+      const { width } = browserWindow.getContentBounds();
+      return {
+        width: 416,
+        height: 70,
+        x: width - 416,
+        y: VIEW_Y_OFFSET,
+      };
+    },
     tabAssociation: {
       tabId: appWindow.viewManager.selectedId,
       getTabInfo: (tabId) => {
@@ -27,6 +29,9 @@ export const showFindDialog = (browserWindow: BrowserWindow) => {
         const tab = appWindow.viewManager.views.get(tabId);
         tab.findInfo = info;
       },
+    },
+    onWindowBoundsUpdate: (disposition) => {
+      if (disposition === 'resize') dialog.rearrange();
     },
   });
 };

--- a/src/main/dialogs/menu.ts
+++ b/src/main/dialogs/menu.ts
@@ -8,7 +8,7 @@ export const showMenuDialog = (
   y: number,
 ) => {
   const menuWidth = 330;
-  Application.instance.dialogs.show({
+  const dialog = Application.instance.dialogs.show({
     name: 'menu',
     browserWindow,
     getBounds: () => ({
@@ -17,5 +17,8 @@ export const showMenuDialog = (
       x: x - menuWidth + DIALOG_MARGIN,
       y: y - DIALOG_MARGIN_TOP,
     }),
+    onWindowBoundsUpdate: () => {
+      dialog.hide();
+    },
   });
 };

--- a/src/main/dialogs/permissions.ts
+++ b/src/main/dialogs/permissions.ts
@@ -40,7 +40,12 @@ export const requestPermission = (
           return tab.requestedPermission;
         },
       },
+      onWindowBoundsUpdate: (disposition) => {
+        if (disposition === 'resize') dialog.rearrange();
+      },
     });
+
+    if (!dialog) return;
 
     dialog.on('result', (e, result) => {
       resolve(result);

--- a/src/main/dialogs/search.ts
+++ b/src/main/dialogs/search.ts
@@ -53,8 +53,14 @@ export class SearchDialog extends PersistentDialog {
     });
   }
 
+  private onResize = () => {
+    this.hide();
+  };
+
   public async show(browserWindow: BrowserWindow) {
     super.show(browserWindow, true, false);
+
+    browserWindow.once('resize', this.onResize);
 
     this.send('visible', true, {
       id: Application.instance.windows.current.viewManager.selectedId,
@@ -70,5 +76,6 @@ export class SearchDialog extends PersistentDialog {
 
   public hide(bringToTop = false) {
     super.hide(bringToTop);
+    this.browserWindow.removeListener('resize', this.onResize);
   }
 }

--- a/src/main/dialogs/tabgroup.ts
+++ b/src/main/dialogs/tabgroup.ts
@@ -19,6 +19,7 @@ export const showTabGroupDialog = (
       x: tabGroup.x - DIALOG_MARGIN,
       y: TITLEBAR_HEIGHT - DIALOG_MARGIN_TOP,
     }),
+    onWindowBoundsUpdate: () => dialog.hide(),
   });
 
   if (!dialog) return;

--- a/src/main/dialogs/zoom.ts
+++ b/src/main/dialogs/zoom.ts
@@ -19,6 +19,7 @@ export const showZoomDialog = (
       x: x - 280 + DIALOG_MARGIN,
       y: y - DIALOG_MARGIN_TOP,
     }),
+    onWindowBoundsUpdate: () => dialog.hide(),
   });
 
   if (!dialog) return;

--- a/src/main/windows/app.ts
+++ b/src/main/windows/app.ts
@@ -80,12 +80,6 @@ export class AppWindow {
       if (!this.win.isMaximized()) {
         windowState.bounds = this.win.getBounds();
       }
-
-      /*Object.values(this.dialogs).forEach((dialog) => {
-        if (dialog.visible) {
-          dialog.rearrange();
-        }
-      });*/
     });
 
     this.win.on('move', () => {


### PR DESCRIPTION
#### Description of Change

This PR fixes dialogs not respecting window `resize` event.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] PR title follows semantic [commit guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
- [x] PR release notes describe the change, and are capitalized, punctuated, and past tense.

#### Release Notes

Notes: none
