### PR TITLE
fix: process hang due to theme source endless loop

### DIFF
--- a/src/main/models/settings.ts
+++ b/src/main/models/settings.ts
@@ -73,15 +73,18 @@ export class Settings extends EventEmitter {
   };
 
   public update = () => {
+    let themeSource = 'system';
+
     if (this.object.themeAuto) {
       this.object.theme = nativeTheme.shouldUseDarkColors
         ? 'wexond-dark'
         : 'wexond-light';
-
-      nativeTheme.themeSource = 'system';
     } else {
-      nativeTheme.themeSource =
-        this.object.theme === 'wexond-dark' ? 'dark' : 'light';
+      themeSource = this.object.theme === 'wexond-dark' ? 'dark' : 'light';
+    }
+
+    if (themeSource !== nativeTheme.themeSource) {
+      nativeTheme.themeSource = themeSource as any;
     }
 
     Application.instance.dialogs.sendToAll('update-settings', this.object);

--- a/src/main/services/dialogs-service.ts
+++ b/src/main/services/dialogs-service.ts
@@ -305,7 +305,9 @@ export class DialogsService {
   };
 
   public sendToAll = (channel: string, ...args: any[]) => {
-    this.getBrowserViews().forEach((x) => x.webContents.send(channel, ...args));
+    this.getBrowserViews().forEach(
+      (x) => !x.isDestroyed() && x.webContents.send(channel, ...args),
+    );
   };
 
   public get(name: string) {

--- a/src/main/view.ts
+++ b/src/main/view.ts
@@ -200,7 +200,7 @@ export class View {
           this.emitEvent('favicon-updated', fav);
         } catch (e) {
           this.favicon = '';
-          console.error(e);
+          // console.error(e);
         }
       },
     );


### PR DESCRIPTION
#### Description of Change

The `nativeTheme.themeSource` was being updated on `nativeTheme` `updated` event, but also changing `themeSource` caused `updated` event to fire, thus making the process completely hang on macOS.

Closes #455 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] PR title follows semantic [commit guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
- [x] PR release notes describe the change, and are capitalized, punctuated, and past tense.

#### Release Notes

Notes: Fixed process hanging up due to endless loop when changing `themeSource` on macOS.
