### PR TITLE
feat: add a fullscreen view

### DIFF
--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -38,21 +38,21 @@ export const getMainMenu = () => {
   const template: any = [
     ...(isMac
       ? [
-          {
-            label: app.name,
-            submenu: [
-              { role: 'about' },
-              { type: 'separator' },
-              { role: 'services' },
-              { type: 'separator' },
-              { role: 'hide' },
-              { role: 'hideothers' },
-              { role: 'unhide' },
-              { type: 'separator' },
-              { role: 'quit' },
-            ],
-          },
-        ]
+        {
+          label: app.name,
+          submenu: [
+            { role: 'about' },
+            { type: 'separator' },
+            { role: 'services' },
+            { type: 'separator' },
+            { role: 'hide' },
+            { role: 'hideothers' },
+            { role: 'unhide' },
+            { type: 'separator' },
+            { role: 'quit' },
+          ],
+        },
+      ]
       : []),
     {
       label: 'File',
@@ -149,15 +149,15 @@ export const getMainMenu = () => {
         { role: 'paste' },
         ...(isMac
           ? [
-              { role: 'pasteAndMatchStyle' },
-              { role: 'delete' },
-              { role: 'selectAll' },
-              { type: 'separator' },
-              {
-                label: 'Speech',
-                submenu: [{ role: 'startspeaking' }, { role: 'stopspeaking' }],
-              },
-            ]
+            { role: 'pasteAndMatchStyle' },
+            { role: 'delete' },
+            { role: 'selectAll' },
+            { type: 'separator' },
+            {
+              label: 'Speech',
+              submenu: [{ role: 'startspeaking' }, { role: 'stopspeaking' }],
+            },
+          ]
           : [{ role: 'delete' }, { type: 'separator' }, { role: 'selectAll' }]),
         { type: 'separator' },
         ...createMenuItem(
@@ -331,14 +331,15 @@ export const getMainMenu = () => {
       label: 'Window',
       submenu: [
         { role: 'minimize' },
+        { role: 'togglefullscreen' },
         { role: 'zoom' },
         ...(isMac
           ? [
-              { type: 'separator' },
-              { role: 'front' },
-              { type: 'separator' },
-              { role: 'window' },
-            ]
+            { type: 'separator' },
+            { role: 'front' },
+            { type: 'separator' },
+            { role: 'window' },
+          ]
           : [{ role: 'close', accelerator: '' }]),
         { type: 'separator' },
         {

--- a/src/renderer/constants/icons.ts
+++ b/src/renderer/constants/icons.ts
@@ -52,6 +52,7 @@ export const ICON_MAGNIFY_PLUS = require('~/renderer/resources/icons/magnify-plu
 export const ICON_MAGNIFY_MINUS = require('~/renderer/resources/icons/magnify-minus.svg');
 export const ICON_VOLUME_HIGH = require('~/renderer/resources/icons/volume-high.svg');
 export const ICON_VOLUME_OFF = require('~/renderer/resources/icons/volume-off.svg');
+export const ICON_FULLSCREEN_EXIT = require('~/renderer/resources/icons/fullscreen-exit.svg');
 
 export const ICON_WEATHER_DAY_CLEAR = require('~/renderer/resources/icons/weather/day/clear.png');
 export const ICON_WEATHER_DAY_FEW_CLOUDS = require('~/renderer/resources/icons/weather/day/few-clouds.png');

--- a/src/renderer/resources/icons/fullscreen-exit.svg
+++ b/src/renderer/resources/icons/fullscreen-exit.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M14,14H19V16H16V19H14V14M5,14H10V19H8V16H5V14M8,5H10V10H5V8H8V5M19,8V10H14V5H16V8H19Z" /></svg>

--- a/src/renderer/views/app/components/App/index.tsx
+++ b/src/renderer/views/app/components/App/index.tsx
@@ -20,7 +20,13 @@ import {
 
 const onAppLeave = () => {
   store.barHideTimer = setTimeout(
-    function () { store.titlebarVisible = false; },
+    function () {
+      if (Object.keys(store.dialogsVisibility).some(k => store.dialogsVisibility[k])) {
+        onAppLeave()
+      } else {
+        store.titlebarVisible = false;
+      }
+    },
     500
   );
 }

--- a/src/renderer/views/app/components/App/index.tsx
+++ b/src/renderer/views/app/components/App/index.tsx
@@ -55,7 +55,7 @@ const App = observer(() => {
         tabHeight: store.isCompact ? COMPACT_TAB_HEIGHT : DEFAULT_TAB_HEIGHT,
       }}
     >
-      <StyledApp onMouseOver={onAppEnter} onMouseLeave={onAppLeave} style={{ height: !store.isFullscreen || store.titlebarVisible ? null : 0 }}>
+      <StyledApp onMouseOver={store.isFullscreen ? onAppEnter : undefined} onMouseLeave={store.isFullscreen ? onAppLeave : undefined} style={{ height: !store.isFullscreen || store.titlebarVisible ? null : 0 }}>
         <UIStyle />
         <Titlebar />
         {store.settings.object.topBarVariant === 'default' && <Toolbar />}

--- a/src/renderer/views/app/components/App/index.tsx
+++ b/src/renderer/views/app/components/App/index.tsx
@@ -3,7 +3,7 @@ import { hot } from 'react-hot-loader/root';
 import * as React from 'react';
 import { ThemeProvider } from 'styled-components';
 
-import { StyledApp } from './style';
+import { StyledApp, Line } from './style';
 import { Titlebar } from '../Titlebar';
 import { Toolbar } from '../Toolbar';
 import store from '../../store';
@@ -17,6 +17,21 @@ import {
   COMPACT_TAB_HEIGHT,
   DEFAULT_TAB_HEIGHT,
 } from '~/constants/design';
+
+const onAppLeave = () => {
+  store.barHideTimer = setTimeout(
+    function () { store.titlebarVisible = false; },
+    500
+  );
+}
+
+const onAppEnter = () => {
+  clearTimeout(store.barHideTimer);
+}
+
+const onLineEnter = () => {
+  store.titlebarVisible = true;
+}
 
 const App = observer(() => {
   return (
@@ -34,12 +49,16 @@ const App = observer(() => {
         tabHeight: store.isCompact ? COMPACT_TAB_HEIGHT : DEFAULT_TAB_HEIGHT,
       }}
     >
-      <StyledApp>
+      <StyledApp onMouseOver={onAppEnter} onMouseLeave={onAppLeave} style={{ height: !store.isFullscreen || store.titlebarVisible ? null : 0 }}>
         <UIStyle />
         <Titlebar />
         {store.settings.object.topBarVariant === 'default' && <Toolbar />}
         <BookmarkBar />
       </StyledApp>
+      <Line
+        onMouseOver={onLineEnter}
+        style={{ height: store.isFullscreen && !store.titlebarVisible ? 1 : 0 }}
+      />
     </ThemeProvider>
   );
 });

--- a/src/renderer/views/app/components/App/style.ts
+++ b/src/renderer/views/app/components/App/style.ts
@@ -5,12 +5,9 @@ import { ITheme } from '~/interfaces';
 export const Line = styled.div`
   height: 1px;
   width: 100%;
-  z-index: 2;
+  z-index: 100;
   position: relative;
-
-  ${({ theme }: { theme: ITheme }) => css`
-    background-color: ${theme['toolbar.bottomLine.backgroundColor']};
-  `}
+  background-color: black;
 `;
 
 export const StyledApp = styled.div`

--- a/src/renderer/views/app/components/Titlebar/index.tsx
+++ b/src/renderer/views/app/components/Titlebar/index.tsx
@@ -1,12 +1,12 @@
 import { observer } from 'mobx-react-lite';
 import * as React from 'react';
-import { ipcRenderer } from 'electron';
+import { ipcRenderer, remote } from 'electron';
 
 import store from '../../store';
 import { Tabbar } from '../Tabbar';
 import { platform } from 'os';
 import { WindowsControls } from 'react-windows-controls';
-import { StyledTitlebar } from './style';
+import { StyledTitlebar, FullscreenExitButton } from './style';
 import { NavigationButtons } from '../NavigationButtons';
 import { RightButtons } from '../RightButtons';
 import { Separator } from '../RightButtons/style';
@@ -26,6 +26,10 @@ const onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
   }
 };
 
+const onFullscreenExit = (e: React.MouseEvent<HTMLDivElement>) => {
+  remote.getCurrentWindow().setFullScreen(false);
+};
+
 export const Titlebar = observer(() => {
   return (
     <StyledTitlebar
@@ -38,17 +42,25 @@ export const Titlebar = observer(() => {
       {store.isCompact && <RightButtons />}
 
       {platform() !== 'darwin' && (
-        <WindowsControls
-          style={{
-            height: store.isCompact ? '100%' : 32,
-            WebkitAppRegion: 'no-drag',
-            marginLeft: 8,
-          }}
-          onClose={onCloseClick}
-          onMinimize={onMinimizeClick}
-          onMaximize={onMaximizeClick}
-          dark={store.theme['toolbar.lightForeground']}
-        />
+        store.isFullscreen
+          ? <FullscreenExitButton
+            style={{
+              height: store.isCompact ? '100%' : 32,
+            }}
+            onMouseUp={onFullscreenExit}
+            theme={store.theme}
+          />
+          : <WindowsControls
+            style={{
+              height: store.isCompact ? '100%' : 32,
+              WebkitAppRegion: 'no-drag',
+              marginLeft: 8,
+            }}
+            onClose={onCloseClick}
+            onMinimize={onMinimizeClick}
+            onMaximize={onMaximizeClick}
+            dark={store.theme['toolbar.lightForeground']}
+          />
       )}
     </StyledTitlebar>
   );

--- a/src/renderer/views/app/components/Titlebar/style.ts
+++ b/src/renderer/views/app/components/Titlebar/style.ts
@@ -1,6 +1,8 @@
 import styled, { css } from 'styled-components';
 import { ITheme } from '~/interfaces';
 import { platform } from 'os';
+import { ICON_FULLSCREEN_EXIT } from '~/renderer/constants/icons'
+import { centerIcon } from '~/renderer/mixins';
 
 // margin-top: ${isHTMLFullscreen ? -TOOLBAR_HEIGHT : 0}px;
 
@@ -24,17 +26,39 @@ export const StyledTitlebar = styled.div`
   }
 
   ${({
-    isHTMLFullscreen,
-    isFullscreen,
-    theme,
-  }: {
-    isHTMLFullscreen: boolean;
-    isFullscreen: boolean;
-    theme: ITheme;
-  }) => css`
+  isHTMLFullscreen,
+  isFullscreen,
+  theme,
+}: {
+  isHTMLFullscreen: boolean;
+  isFullscreen: boolean;
+  theme: ITheme;
+}) => css`
     background-color: ${theme['titlebar.backgroundColor']};
     height: ${theme.titlebarHeight}px;
     align-items: ${theme.isCompact ? 'center' : 'initial'};
     padding-left: ${platform() === 'darwin' && !isFullscreen ? 78 : 4}px;
   `};
+`;
+
+export const FullscreenExitButton = styled.div`
+  top: 0;
+  right: 0;
+  height: 32px;
+  min-width: 45px;
+  -webkit-app-region: no-drag;
+  marginLeft: 8;
+  background-image: url(${ICON_FULLSCREEN_EXIT});
+  transition: 0.1s background-color;
+  ${centerIcon(24)};
+
+  ${({ theme }: { theme?: ITheme }) => css`
+    filter: ${theme['dialog.lightForeground']
+      ? `invert(100%)`
+      : `none`};
+  `}
+
+  &:hover {
+    background-color: rgba(60, 60, 60, 0.4);
+  }
 `;

--- a/src/renderer/views/app/components/Titlebar/style.ts
+++ b/src/renderer/views/app/components/Titlebar/style.ts
@@ -21,7 +21,6 @@ export const StyledTitlebar = styled.div`
     left: 4px;
     right: 4px;
     bottom: 0px;
-    -webkit-app-region: drag;
     content: '';
   }
 
@@ -38,6 +37,10 @@ export const StyledTitlebar = styled.div`
     height: ${theme.titlebarHeight}px;
     align-items: ${theme.isCompact ? 'center' : 'initial'};
     padding-left: ${platform() === 'darwin' && !isFullscreen ? 78 : 4}px;
+
+    &:before {
+      -webkit-app-region: ${isFullscreen ? 'no-drag' : 'drag'};
+    }
   `};
 `;
 

--- a/src/renderer/views/app/store/index.ts
+++ b/src/renderer/views/app/store/index.ts
@@ -126,6 +126,9 @@ export class Store {
   public isHTMLFullscreen = false;
 
   @observable
+  public titlebarVisible = false;
+
+  @observable
   public updateAvailable = false;
 
   @observable
@@ -181,6 +184,8 @@ export class Store {
   };
 
   public windowId = getCurrentWindow().id;
+
+  public barHideTimer = null;
 
   @observable
   public isIncognito = ipcRenderer.sendSync(`is-incognito-${this.windowId}`);

--- a/src/renderer/views/app/store/index.ts
+++ b/src/renderer/views/app/store/index.ts
@@ -185,7 +185,7 @@ export class Store {
 
   public windowId = getCurrentWindow().id;
 
-  public barHideTimer = null;
+  public barHideTimer = 0;
 
   @observable
   public isIncognito = ipcRenderer.sendSync(`is-incognito-${this.windowId}`);


### PR DESCRIPTION
#### Description of Change

This PR adds a fullscreen view to wexond, based on firefox's design.
In this implementation, the top bar is normally hidden:
![FS_Normal](https://user-images.githubusercontent.com/14961554/84392834-22f76100-abfb-11ea-850c-8969d9b92e49.png)

..until the mouse reaches a 1px high, black collider (like in firefox), which results in the top bar being shown:
![FS_Mouseclose](https://user-images.githubusercontent.com/14961554/84393066-69e55680-abfb-11ea-86e2-9b8d31fe828b.png)
![FS_Fullsize_Mouseclose](https://user-images.githubusercontent.com/14961554/84393075-6baf1a00-abfb-11ea-9ef4-be0f5890597e.png)

The top bar afterwards hides if no widget is open and the mouse left the top bar.

#### Checklist

- [x] PR description included
- [x] PR title follows semantic [commit guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
- [x] PR release notes describe the change, and are capitalized, punctuated, and past tense.

#### Release Notes

Notes: Added a fullscreen view
