### PR TITLE
chore: drop linux 32 support

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -17,11 +17,11 @@
     "target": [
       {
         "target": "AppImage",
-        "arch": ["ia32", "x64"]
+        "arch": ["x64"]
       },
       {
         "target": "deb",
-        "arch": ["ia32", "x64"]
+        "arch": ["x64"]
       }
     ]
   },


### PR DESCRIPTION
#### Description of Change

Drops support for ia32 Linux.

#### Release Notes

Notes: Dropped support for Linux ia32.
