### PR TITLE
feat: show favicon from cache when loading a URL

### DIFF
--- a/src/browser/extensions/api/tabs.ts
+++ b/src/browser/extensions/api/tabs.ts
@@ -391,8 +391,12 @@ export class TabsAPI extends EventHandler implements ITabsEvents {
       this.onUpdated(tab);
     });
 
-    tab.on('page-favicon-updated', (event, favicons) => {
+    tab.on('page-favicon-updated', async (event, favicons) => {
       tab.favicon = favicons[0];
+      await Application.instance.storage.favicons.saveFavicon(
+        tab.getURL(),
+        tab.favicon,
+      );
       this.onUpdated(tab);
     });
 

--- a/src/browser/protocols/wexond.ts
+++ b/src/browser/protocols/wexond.ts
@@ -23,7 +23,7 @@ export default {
             parsed.path.substr(1),
           );
 
-          console.log(favicon.toString('base64'));
+          console.log(favicon?.toString('base64'));
 
           if (favicon) {
             buffer = favicon;

--- a/src/browser/protocols/wexond.ts
+++ b/src/browser/protocols/wexond.ts
@@ -19,11 +19,11 @@ export default {
         let mimeType: string;
 
         if (parsed.hostname === 'favicon') {
-          const favicon = await Application.instance.storage.favicons.getFavicon(
-            parsed.path.substr(1),
+          const favicon = Buffer.from(
+            await Application.instance.storage.favicons.getFavicon(
+              parsed.path.substr(1),
+            ),
           );
-
-          console.log(favicon?.toString('base64'));
 
           if (favicon) {
             buffer = favicon;

--- a/src/browser/protocols/wexond.ts
+++ b/src/browser/protocols/wexond.ts
@@ -23,6 +23,8 @@ export default {
             parsed.path.substr(1),
           );
 
+          console.log(favicon.toString('base64'));
+
           if (favicon) {
             buffer = favicon;
             mimeType = 'image/png';

--- a/src/browser/services/favicons.ts
+++ b/src/browser/services/favicons.ts
@@ -1,6 +1,7 @@
 import { Worker } from 'worker_threads';
 
 import { WorkerMessengerFactory } from '~/common/worker-messenger-factory';
+import { bufferFromUint8Array } from '~/common/utils/buffer';
 
 export class FaviconsService {
   private invoker = WorkerMessengerFactory.createInvoker('favicons');
@@ -9,9 +10,15 @@ export class FaviconsService {
     this.invoker.initialize(worker);
   }
 
-  public getFavicon = (pageUrl: string) =>
-    this.invoker.invoke<Buffer>('getFavicon', pageUrl);
+  public getFavicon = async (pageUrl: string) => {
+    return bufferFromUint8Array(
+      await this.invoker.invoke<Uint8Array>('getFavicon', pageUrl),
+    );
+  };
 
-  public saveFavicon = (pageUrl: string, faviconUrl: string) =>
-    this.invoker.invoke<Buffer>('saveFavicon', pageUrl, faviconUrl);
+  public saveFavicon = async (pageUrl: string, faviconUrl: string) => {
+    return bufferFromUint8Array(
+      await this.invoker.invoke<Uint8Array>('saveFavicon', pageUrl, faviconUrl),
+    );
+  };
 }

--- a/src/browser/tabs.ts
+++ b/src/browser/tabs.ts
@@ -49,12 +49,11 @@ export class Tabs {
     });
 
     extensions.tabs.on('updated', (tabId, changeInfo, details) => {
-      if (changeInfo.favIconUrl) {
-        Application.instance.storage.favicons.saveFavicon(
-          details.url,
-          changeInfo.favIconUrl,
-        );
-      }
+      console.log(details.url);
+      Application.instance.storage.favicons.saveFavicon(
+        details.url,
+        details.favIconUrl,
+      );
 
       if (changeInfo.url) {
         Application.instance.storage.history.addUrl({

--- a/src/browser/tabs.ts
+++ b/src/browser/tabs.ts
@@ -49,10 +49,14 @@ export class Tabs {
     });
 
     extensions.tabs.on('updated', (tabId, changeInfo, details) => {
-      Application.instance.storage.favicons.saveFavicon(
-        details.url,
-        details.favIconUrl,
-      );
+      const { url, favIconUrl } = details;
+
+      if (url && favIconUrl) {
+        Application.instance.storage.favicons.saveFavicon(
+          details.url,
+          details.favIconUrl,
+        );
+      }
 
       if (changeInfo.url) {
         Application.instance.storage.history.addUrl({

--- a/src/browser/tabs.ts
+++ b/src/browser/tabs.ts
@@ -49,7 +49,6 @@ export class Tabs {
     });
 
     extensions.tabs.on('updated', (tabId, changeInfo, details) => {
-      console.log(details.url);
       Application.instance.storage.favicons.saveFavicon(
         details.url,
         details.favIconUrl,

--- a/src/browser/tabs.ts
+++ b/src/browser/tabs.ts
@@ -49,15 +49,6 @@ export class Tabs {
     });
 
     extensions.tabs.on('updated', (tabId, changeInfo, details) => {
-      const { url, favIconUrl } = details;
-
-      if (url && favIconUrl) {
-        Application.instance.storage.favicons.saveFavicon(
-          details.url,
-          details.favIconUrl,
-        );
-      }
-
       if (changeInfo.url) {
         Application.instance.storage.history.addUrl({
           url: details.url,

--- a/src/common/utils/buffer.ts
+++ b/src/common/utils/buffer.ts
@@ -1,0 +1,3 @@
+export const bufferFromUint8Array = (array: Uint8Array) => {
+  return Buffer.from(new Uint8Array(array));
+};

--- a/src/renderer/components/Preloader/index.tsx
+++ b/src/renderer/components/Preloader/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { BLUE_500 } from '~/renderer/constants';
-import { Path, StyledPreloader } from './style';
+import { Path, StyledPreloader, Spinner } from './style';
 
 export interface Props {
   style?: any;
@@ -23,19 +23,22 @@ export const Preloader = ({
   return (
     <div style={style}>
       <StyledPreloader indeterminate={indeterminate} size={size}>
-        <svg viewBox="25 25 50 50">
+        <Spinner
+          stroke={color}
+          viewBox="0 0 66 66"
+          indeterminate={indeterminate}
+        >
           <Path
-            cx="50"
-            cy="50"
-            r="20"
-            fill="none"
-            strokeMiterlimit="10"
-            color={color}
-            thickness={thickness}
             indeterminate={indeterminate}
             value={value}
-          />
-        </svg>
+            fill="none"
+            strokeWidth={thickness}
+            strokeLinecap="square"
+            cx="33"
+            cy="33"
+            r="30"
+          ></Path>
+        </Spinner>
       </StyledPreloader>
     </div>
   );

--- a/src/renderer/components/Preloader/style.ts
+++ b/src/renderer/components/Preloader/style.ts
@@ -1,58 +1,64 @@
 import styled, { css } from 'styled-components';
 
-export const StyledPreloader = styled.div`
-  transform-origin: center center;
-  z-index: 5;
-  transform: rotate(-89deg);
-  ${({ size, indeterminate }: { size: number; indeterminate: boolean }) => css`
-    width: ${size}px;
-    height: ${size}px;
-    animation: ${indeterminate ? `preloader-rotate 2s linear infinite` : ''};
+export const Spinner = styled.svg`
+  transform-origin: center;
+
+  ${({ indeterminate }: { indeterminate: boolean }) => css`
+    animation: ${indeterminate ? `rotation 1.35s linear infinite` : ''};
   `};
 
-  @keyframes preloader-rotate {
+  @keyframes turn {
+    0% {
+      stroke-dashoffset: 180;
+    }
+
+    50% {
+      stroke-dashoffset: 45;
+      -webkit-transform: rotate(135deg);
+      transform: rotate(135deg);
+    }
+
     100% {
-      -webkit-transform: rotate(360deg);
-      transform: rotate(360deg);
+      stroke-dashoffset: 180;
+      -webkit-transform: rotate(450deg);
+      transform: rotate(450deg);
     }
   }
-  @keyframes preloader-dash {
+
+  @keyframes rotation {
     0% {
-      stroke-dasharray: 1, 200;
-      stroke-dashoffset: 0;
+      -webkit-transform: rotate(0deg);
+      transform: rotate(0deg);
     }
-    50% {
-      stroke-dasharray: 89, 200;
-      stroke-dashoffset: -35px;
-    }
+
     100% {
-      stroke-dasharray: 89, 200;
-      stroke-dashoffset: -124px;
+      -webkit-transform: rotate(270deg);
+      transform: rotate(270deg);
     }
   }
 `;
 
+export const StyledPreloader = styled.div`
+  z-index: 5;
+
+  ${({ size, indeterminate }: { size: number; indeterminate: boolean }) => css`
+    width: ${size}px;
+    height: ${size}px;
+  `};
+`;
+
 export const Path = styled.circle`
   stroke-linecap: square;
+  transform-origin: center;
+
   ${({
-    color,
-    thickness,
     value,
     indeterminate,
   }: {
-    color: string;
-    thickness: number;
     value: number;
     indeterminate: boolean;
   }) => css`
-    stroke-dasharray: ${indeterminate ? '1, 200' : `199, 200`};
-    stroke-dashoffset: ${199 - value * (199 - 82)}px;
-    stroke-width: ${thickness};
-    stroke: ${color};
-    animation: ${indeterminate
-      ? `preloader-dash 1.5s ease-in-out infinite,
-    color 6s ease-in-out infinite`
-      : ''};
-    transition: 0.3s stroke ${indeterminate ? ', 0.3s stroke-dasharray' : ''};
+    stroke-dasharray: ${indeterminate ? '180' : `0`};
+    animation: ${indeterminate ? `turn 1.35s ease-in-out infinite` : ''};
   `};
 `;

--- a/src/renderer/views/app/components/Tab/index.tsx
+++ b/src/renderer/views/app/components/Tab/index.tsx
@@ -212,18 +212,21 @@ const onContextMenu = (tab: ITab) => () => {
 };
 
 const Content = observer(({ tab }: { tab: ITab }) => {
+  const loading = true;
+
   return (
     <StyledContent>
-      {!tab.loading && tab.favicon !== '' && (
+      {tab.favicon !== '' && (
         <StyledIcon
           isIconSet={tab.favicon !== ''}
+          loading={loading}
           style={{ backgroundImage: `url(${tab.favicon})` }}
         >
           <PinnedVolume tab={tab} />
         </StyledIcon>
       )}
 
-      {tab.loading && (
+      {loading && (
         <Preloader
           color={store.theme.accentColor}
           thickness={6}

--- a/src/renderer/views/app/components/Tab/index.tsx
+++ b/src/renderer/views/app/components/Tab/index.tsx
@@ -212,7 +212,7 @@ const onContextMenu = (tab: ITab) => () => {
 };
 
 const Content = observer(({ tab }: { tab: ITab }) => {
-  const loading = true;
+  const loading = !!tab.loading;
 
   return (
     <StyledContent>
@@ -232,7 +232,7 @@ const Content = observer(({ tab }: { tab: ITab }) => {
           thickness={6}
           size={16}
           indeterminate
-          style={{ minWidth: 16 }}
+          style={{ minWidth: 16, position: 'absolute', left: 0, marginTop: -1 }}
         />
       )}
       {!tab.isPinned && (

--- a/src/renderer/views/app/components/Tab/style.ts
+++ b/src/renderer/views/app/components/Tab/style.ts
@@ -125,7 +125,7 @@ export const StyledTitle = styled.div`
   flex: 1;
 
   ${({ isIcon, selected, theme }: TitleProps) => css`
-    margin-left: ${!isIcon ? 0 : 12}px;
+    margin-left: ${!isIcon ? 0 : 24}px;
     color: ${selected
       ? theme['tab.selected.textColor']
       : theme['tab.textColor']};
@@ -135,9 +135,13 @@ export const StyledTitle = styled.div`
 export const StyledIcon = styled.div`
   height: 16px;
   min-width: 16px;
-  transition: 0.2s opacity, 0.2s min-width;
+  transition: 0.2s opacity, 0.2s min-width, 0.2s transform;
+  position: absolute;
+  left: 0;
+  transform-origin: center;
   ${centerIcon()};
-  ${({ isIconSet }: { isIconSet: boolean }) => css`
+  ${({ isIconSet, loading }: { isIconSet: boolean; loading: boolean }) => css`
+    transform: scale(${loading ? 0.7 : 1});
     min-width: ${isIconSet ? 0 : 16},
     opacity: ${isIconSet ? 0 : 1};
   `};
@@ -147,6 +151,7 @@ export const StyledContent = styled.div`
   overflow: hidden;
   z-index: 2;
   align-items: center;
+  position: relative;
   display: flex;
   margin-left: 10px;
   flex: 1;

--- a/src/renderer/views/app/components/Tab/style.ts
+++ b/src/renderer/views/app/components/Tab/style.ts
@@ -135,15 +135,16 @@ export const StyledTitle = styled.div`
 export const StyledIcon = styled.div`
   height: 16px;
   min-width: 16px;
-  transition: 0.2s opacity, 0.2s min-width, 0.2s transform;
+  transition: 0.2s opacity, 0.2s min-width, 0.15s transform, 0.15s border-radius;
   position: absolute;
   left: 0;
   transform-origin: center;
   ${centerIcon()};
   ${({ isIconSet, loading }: { isIconSet: boolean; loading: boolean }) => css`
-    transform: scale(${loading ? 0.7 : 1});
+    transform: scale(${loading ? 0.65 : 1});
     min-width: ${isIconSet ? 0 : 16},
     opacity: ${isIconSet ? 0 : 1};
+    border-radius: ${loading ? '50%' : 0};
   `};
 `;
 

--- a/src/renderer/views/app/store/tabs.ts
+++ b/src/renderer/views/app/store/tabs.ts
@@ -240,8 +240,7 @@ export class TabsStore {
         if (title) tab.title = title;
         if (mutedInfo) tab.isMuted = mutedInfo.muted;
         if (audible !== undefined) tab.isPlaying = audible;
-        // if (favIconUrl)
-        //   tab.favicon = `wexond://favicon/${details.url}?v=${randomId()}`;
+        if (favIconUrl) tab.favicon = `wexond://favicon/${details.url}`;
         if (url) {
           tab.url = url;
           tab.favicon = `wexond://favicon/${url}`;

--- a/src/renderer/views/app/store/tabs.ts
+++ b/src/renderer/views/app/store/tabs.ts
@@ -235,8 +235,9 @@ export class TabsStore {
         if (title) tab.title = title;
         if (mutedInfo) tab.isMuted = mutedInfo.muted;
         if (audible !== undefined) tab.isPlaying = audible;
-        if (favIconUrl) tab.favicon = favIconUrl;
+        //if (favIconUrl) tab.favicon = favIconUrl;
         if (url) {
+          tab.favicon = `wexond://favicon/${url}`;
           tab.url = url;
           if (tab.id === this.selectedTabId && !store.addressbarFocused) {
             this.selectedTab.addressbarValue = null;

--- a/src/renderer/views/app/store/tabs.ts
+++ b/src/renderer/views/app/store/tabs.ts
@@ -11,6 +11,7 @@ import {
 
 import store from '.';
 import { TOOLBAR_HEIGHT } from '~/constants/design';
+import { randomId } from '~/common/utils/string';
 
 export class TabsStore {
   @observable
@@ -227,7 +228,11 @@ export class TabsStore {
     });
 
     browser.tabs.onUpdated.addListener(
-      async (tabId, { title, status, mutedInfo, audible, favIconUrl, url }) => {
+      async (
+        tabId,
+        { title, status, mutedInfo, audible, favIconUrl, url },
+        details,
+      ) => {
         const tab = this.getTabById(tabId);
         if (!tab) return;
 
@@ -235,10 +240,12 @@ export class TabsStore {
         if (title) tab.title = title;
         if (mutedInfo) tab.isMuted = mutedInfo.muted;
         if (audible !== undefined) tab.isPlaying = audible;
-        //if (favIconUrl) tab.favicon = favIconUrl;
+        // if (favIconUrl)
+        //   tab.favicon = `wexond://favicon/${details.url}?v=${randomId()}`;
         if (url) {
-          tab.favicon = `wexond://favicon/${url}`;
           tab.url = url;
+          tab.favicon = `wexond://favicon/${url}`;
+
           if (tab.id === this.selectedTabId && !store.addressbarFocused) {
             this.selectedTab.addressbarValue = null;
           }

--- a/src/storage/services/db.ts
+++ b/src/storage/services/db.ts
@@ -19,6 +19,7 @@ class DbService {
     this.favicons = await this.createDb(
       config.favicons,
       config.default.favicons,
+      true,
     );
 
     await BookmarksService.start();
@@ -27,10 +28,10 @@ class DbService {
     FaviconsService.start();
   }
 
-  private async createDb(path: string, schemaPath: string) {
+  private async createDb(path: string, schemaPath: string, verbose = false) {
     const exists = await pathExists(path);
 
-    const db = sqlite(path, {/* verbose: console.log*/ });
+    const db = sqlite(path, { verbose: verbose ? console.log : undefined });
 
     if (!exists) {
       const schema = await fs.readFile(schemaPath, 'utf8');

--- a/src/storage/services/db.ts
+++ b/src/storage/services/db.ts
@@ -30,7 +30,7 @@ class DbService {
   private async createDb(path: string, schemaPath: string) {
     const exists = await pathExists(path);
 
-    const db = sqlite(path, { verbose: console.log });
+    const db = sqlite(path, {/* verbose: console.log*/ });
 
     if (!exists) {
       const schema = await fs.readFile(schemaPath, 'utf8');

--- a/src/storage/services/favicons.ts
+++ b/src/storage/services/favicons.ts
@@ -6,6 +6,7 @@ import DbService from './db';
 import { WorkerMessengerFactory } from '~/common/worker-messenger-factory';
 import { convertIcoToPng } from '../utils';
 import { dateToChromeTime } from '~/common/utils/date';
+import { Queue } from '~/utils/queue';
 
 class FaviconsService {
   public start() {
@@ -31,6 +32,8 @@ class FaviconsService {
       `,
       )
       .get({ pageUrl });
+
+    console.log(pageUrl, data?.image_data.toString('base64'));
 
     return data?.image_data;
   }

--- a/src/storage/services/favicons.ts
+++ b/src/storage/services/favicons.ts
@@ -36,11 +36,25 @@ class FaviconsService {
   }
 
   private addIconMapping(iconId: number, pageUrl: string) {
-    this.db
-      .prepare(
-        `INSERT INTO icon_mapping (page_url, icon_id) VALUES (@pageUrl, @iconId)`,
-      )
-      .run({ pageUrl, iconId });
+    const iconMapping = this.db
+      .prepare(`SELECT icon_id FROM icon_mapping WHERE page_url = @pageUrl`)
+      .get({ pageUrl });
+
+    if (iconMapping) {
+      if (iconMapping.icon_id === iconId) return;
+
+      this.db
+        .prepare(
+          `UPDATE icon_mapping SET icon_id = @iconId WHERE page_url = @pageUrl`,
+        )
+        .run({ pageUrl, iconId });
+    } else {
+      this.db
+        .prepare(
+          `INSERT INTO icon_mapping (page_url, icon_id) VALUES (@pageUrl, @iconId)`,
+        )
+        .run({ pageUrl, iconId });
+    }
   }
 
   public async saveFavicon(pageUrl: string, faviconUrl: string) {

--- a/src/storage/services/favicons.ts
+++ b/src/storage/services/favicons.ts
@@ -81,30 +81,27 @@ class FaviconsService {
 
       this.addIconMapping(iconId, pageUrl);
 
-      const bitmapOptions = {
-        iconId,
-        lastUpdated: dateToChromeTime(new Date()),
-      };
+      const bitmap = this.insertBitmap(iconId);
 
-      const bitmapSql = this.db.prepare(
-        `INSERT INTO favicon_bitmaps (icon_id, last_updated, image_data, width, height, last_requested) VALUES (@iconId, @lastUpdated, @imageData, @width, @height, 0)`,
-      );
-
-      bitmapSql.run({
-        ...bitmapOptions,
-        imageData: image16,
-        width: 16,
-        height: 16,
-      });
-
-      bitmapSql.run({
-        ...bitmapOptions,
-        imageData: image32,
-        width: 32,
-        height: 32,
-      });
+      bitmap(image16, 16);
+      bitmap(image32, 32);
     })();
   }
+
+  private insertBitmap = (iconId: number) => {
+    const options = {
+      iconId,
+      lastUpdated: dateToChromeTime(new Date()),
+    };
+
+    const query = this.db.prepare(
+      `INSERT INTO favicon_bitmaps (icon_id, last_updated, image_data, width, height, last_requested) VALUES (@iconId, @lastUpdated, @imageData, @width, @height, 0)`,
+    );
+
+    return (buffer: Buffer, size: number) => {
+      query.run({ ...options, imageData: buffer, width: size, height: size });
+    };
+  };
 
   private async processFavicon(buffer: Buffer) {
     const type = await fromBuffer(buffer);

--- a/src/storage/utils/image.ts
+++ b/src/storage/utils/image.ts
@@ -1,7 +1,9 @@
 import * as icojs from 'icojs';
 
+import { bufferFromUint8Array } from '~/common/utils/buffer';
+
 export const convertIcoToPng = async (icoData: Buffer) => {
-  return Buffer.from(
+  return bufferFromUint8Array(
     new Uint8Array((await icojs.parse(icoData, 'image/png'))[0].buffer),
   );
 };


### PR DESCRIPTION
#### Description of Change

Adds a small favicon preview in a tab preloader from favicons cache.

![image](https://user-images.githubusercontent.com/11065386/85201489-098f9c80-b300-11ea-8307-95f0876b24b4.png)

#### Release Notes

Notes: Favicon is now displayed during page load.
