### PR TITLE
feat: show domain on active tab [compact]

### DIFF
--- a/src/renderer/views/app/components/Tab/index.tsx
+++ b/src/renderer/views/app/components/Tab/index.tsx
@@ -238,7 +238,7 @@ const Content = observer(({ tab }: { tab: ITab }) => {
       )}
       {!tab.isPinned && (
         <StyledTitle isIcon={tab.isIconSet} selected={tab.isSelected}>
-          {tab.title}
+          {tab.isSelected && store.isCompact ? tab.url : tab.title}
         </StyledTitle>
       )}
       <ExpandedVolume tab={tab} />


### PR DESCRIPTION
Make the active tab actually transform to an address bar of sorts, like one that takes the width of too tabs. That would give even better overview as the user can see the whole URL.

#### Description of Change

feat: Selected compact tabs are showing URL instead of title!

Closes #529

#### Checklist

- [x] PR description included
- [x] PR title follows semantic [commit guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
- [x] PR release notes describe the change, and are capitalized, punctuated, and past tense.

#### Release Notes

Notes: Selected compact tabs are showing URL instead of title.
