### PR TITLE
fix: Prevent access to color of possible undefined tabGroup

### DIFF
--- a/src/renderer/views/app/components/Tab/index.tsx
+++ b/src/renderer/views/app/components/Tab/index.tsx
@@ -317,7 +317,7 @@ export default observer(({ tab }: { tab: ITab }) => {
             : defaultColor,
           borderColor:
             tab.isSelected && tab.tabGroupId !== -1 && !store.isCompact
-              ? tab.tabGroup.color
+              ? tab.tabGroup?.color
               : 'transparent',
         }}
       >


### PR DESCRIPTION
#### Description of Change

fix: Prevent reading color of possible undefined tabGroup
Closes bug: #566 

#### Checklist

- [x] PR description included
- [x] PR title follows semantic [commit guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
- [x] PR release notes describe the change, and are capitalized, punctuated, and past tense.
