### PR TITLE
fix: Prevent additional tabGroups from remaining after deletion

### DIFF
--- a/src/renderer/views/app/components/Tab/index.tsx
+++ b/src/renderer/views/app/components/Tab/index.tsx
@@ -120,6 +120,7 @@ const onContextMenu = (tab: ITab) => () => {
     {
       label: 'Add to a new group',
       click: () => {
+        tab.removeFromGroup();
         const tabGroup = store.tabGroups.addGroup();
         tab.tabGroupId = tabGroup.id;
         store.tabs.updateTabsBounds(true);


### PR DESCRIPTION
#### Description of Change

fix: Prevent additional tabGroups that have been added multiple times from remaining after deletion

![2021-12-02_0-37-38](https://user-images.githubusercontent.com/21088281/144321469-4e3f558a-5d1f-4ef9-9c8a-098bf72d6931.gif)

#### Checklist

- [x] PR description included
- [x] PR title follows semantic [commit guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
- [x] PR release notes describe the change, and are capitalized, punctuated, and past tense.
