### PR TITLE
improvement: Change zoom in or out and reset zoom with keyboard like Chrome

### DIFF
--- a/src/main/menus/main.ts
+++ b/src/main/menus/main.ts
@@ -376,5 +376,26 @@ export const getMainMenu = () => {
     }),
   );
 
+  // Ctrl+numadd - Ctrl+=
+  template[0].submenu = template[0].submenu.concat(
+    createMenuItem(['CmdOrCtrl+numadd', 'CmdOrCtrl+='], () => {
+      Application.instance.windows.current.viewManager.changeZoom('in');
+    }),
+  );
+
+  // Ctrl+numsub - Ctrl+-
+  template[0].submenu = template[0].submenu.concat(
+    createMenuItem(['CmdOrCtrl+numsub', 'CmdOrCtrl+-'], () => {
+      Application.instance.windows.current.viewManager.changeZoom('out');
+    }),
+  );
+
+  // Ctrl+0
+  template[0].submenu = template[0].submenu.concat(
+    createMenuItem(['CmdOrCtrl+0', 'CmdOrCtrl+num0'], () => {
+      Application.instance.windows.current.viewManager.resetZoom();
+    }),
+  );
+
   return Menu.buildFromTemplate(template);
 };

--- a/src/main/view-manager.ts
+++ b/src/main/view-manager.ts
@@ -83,7 +83,27 @@ export class ViewManager extends EventEmitter {
     });
 
     ipcMain.on('change-zoom', (e, zoomDirection) => {
-      const newZoomFactor =
+      this.changeZoom(zoomDirection, e);
+    });
+
+    ipcMain.on('reset-zoom', (e) => {
+      this.resetZoom();
+    });
+
+    this.setBoundsListener();
+  }
+
+  public resetZoom() {
+    this.selected.webContents.zoomFactor = 1;
+    this.selected.emitEvent(
+      'zoom-updated',
+      this.selected.webContents.zoomFactor,
+    );
+    this.emitZoomUpdate();
+  }
+
+  public changeZoom(zoomDirection: 'in' | 'out', e?: any) {
+    const newZoomFactor =
         this.selected.webContents.zoomFactor +
         (zoomDirection === 'in'
           ? ZOOM_FACTOR_INCREMENT
@@ -99,21 +119,9 @@ export class ViewManager extends EventEmitter {
           this.selected.webContents.zoomFactor,
         );
       } else {
-        e.preventDefault();
+        e?.preventDefault();
       }
       this.emitZoomUpdate();
-    });
-
-    ipcMain.on('reset-zoom', (e) => {
-      this.selected.webContents.zoomFactor = 1;
-      this.selected.emitEvent(
-        'zoom-updated',
-        this.selected.webContents.zoomFactor,
-      );
-      this.emitZoomUpdate();
-    });
-
-    this.setBoundsListener();
   }
 
   public get selected() {


### PR DESCRIPTION
#### Description of Change

improvement: You can use the keyboard shortcuts to zoom in or out and reset zoom:

- Make everything larger:
  - Windows and Linux: Press Ctrl and +.
  - Mac: Press ⌘ and +.

- Make everything smaller:
  - Windows and Linux: Press Ctrl and -.
  - Mac: Press ⌘ and -.

- Reset Zoom:
  - Windows and Linux: Press Ctrl and 0.
  - Mac: Press ⌘ and 0.

![2021-12-02_13-05-41](https://user-images.githubusercontent.com/21088281/144407936-0c627c25-f5d0-4d09-bf86-74b635b01162.gif)


#### Checklist

- [x] PR description included
- [x] PR title follows semantic [commit guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
- [x] PR release notes describe the change, and are capitalized, punctuated, and past tense.
