### PR TITLE
fix: Prevent to show developer tools when find in page dialog opened

### DIFF
--- a/src/main/dialogs/find.ts
+++ b/src/main/dialogs/find.ts
@@ -3,14 +3,13 @@ import { BrowserWindow } from 'electron';
 import { Application } from '../application';
 
 export const showFindDialog = (browserWindow: BrowserWindow) => {
-  const appWindow = Application.instance.windows.fromBrowserWindow(
-    browserWindow,
-  );
+  const appWindow =
+    Application.instance.windows.fromBrowserWindow(browserWindow);
 
   const dialog = Application.instance.dialogs.show({
     name: 'find',
     browserWindow,
-    devtools: true,
+    devtools: false,
     getBounds: () => {
       const { width } = browserWindow.getContentBounds();
       return {


### PR DESCRIPTION
#### Description of Change

fix: Prevent to show developer tools when find in page dialog opened
Closes bug: #588 

#### Checklist

- [x] PR description included
- [x] PR title follows semantic [commit guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
- [x] PR release notes describe the change, and are capitalized, punctuated, and past tense.
