### PR TITLE
improvement: Select a tabGroup to assign a tab to it, like Chrome

### DIFF
--- a/src/renderer/views/app/store/tab-groups.ts
+++ b/src/renderer/views/app/store/tab-groups.ts
@@ -72,4 +72,8 @@ export class TabGroupsStore {
     this.list.push(tabGroup);
     return tabGroup;
   }
+
+  public getGroups(): ITabGroup[] {
+    return this.list;
+  }
 }

--- a/src/renderer/views/app/store/tabs.ts
+++ b/src/renderer/views/app/store/tabs.ts
@@ -239,7 +239,8 @@ export class TabsStore {
     requestAnimationFrame(() => {
       this.updateTabsBounds(false);
       if (this.scrollable) {
-        this.containerRef.current.scrollLeft = this.containerRef.current.scrollWidth;
+        this.containerRef.current.scrollLeft =
+          this.containerRef.current.scrollWidth;
       }
     });
 
@@ -251,7 +252,8 @@ export class TabsStore {
 
     const frame = () => {
       if (!this.scrollingToEnd) return;
-      this.containerRef.current.scrollLeft = this.containerRef.current.scrollWidth;
+      this.containerRef.current.scrollLeft =
+        this.containerRef.current.scrollWidth;
       requestAnimationFrame(frame);
     };
 
@@ -457,6 +459,33 @@ export class TabsStore {
       Math.min(left, containerWidth + TABS_PADDING),
       animation,
     );
+  }
+
+  @action
+  public setTabToGroup(tab: ITab, tabGroupId: number) {
+    const tabs = [...this.list];
+
+    const tabIndex = tabs.indexOf(tab);
+    const groupFirstTabIndex = tabs.findIndex(
+      (x) => x.tabGroupId === tabGroupId,
+    );
+
+    const groupLastTab = tabs
+      .slice()
+      .reverse()
+      .find((x) => x.tabGroupId === tabGroupId);
+    const groupLastTabIndex = tabs.indexOf(groupLastTab);
+
+    const groupTabIndex =
+      tabIndex < groupFirstTabIndex
+        ? groupFirstTabIndex - 1
+        : groupLastTabIndex + 1;
+
+    tab.tabGroupId = tabGroupId;
+    tabs.splice(tabIndex, 1);
+    tabs.splice(groupTabIndex, 0, tab);
+    this.list = tabs;
+    this.updateTabsBounds(false);
   }
 
   @action


### PR DESCRIPTION
#### Description of Change

improvement: When you have more than one tabGroup, select a tabGroup to assign a tab to it, like Chrome.

![2021-12-07_1-30-46](https://user-images.githubusercontent.com/21088281/144930409-6f6efd21-9124-475a-a87a-0306e16d9200.gif)

#### Checklist

- [x] PR description included
- [x] PR title follows semantic [commit guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
- [x] PR release notes describe the change, and are capitalized, punctuated, and past tense.

