### PR TITLE
fix: Set a fixed height for the download item progress bar

### DIFF
--- a/src/renderer/views/downloads-dialog/components/DownloadItem/style.ts
+++ b/src/renderer/views/downloads-dialog/components/DownloadItem/style.ts
@@ -43,7 +43,7 @@ export const SecondaryText = styled.div`
 `;
 
 export const Progress = styled.div`
-  height: 100%;
+  height: 5px;
   background-color: ${BLUE_500};
   border-radius: 16px;
 `;


### PR DESCRIPTION
#### Description of Change

fix: Set a fixed height for the download item progress bar to indicate the progress of the download file. (It was not displayed before)

#### Checklist

- [x] PR description included
- [x] PR title follows semantic [commit guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
- [x] PR release notes describe the change, and are capitalized, punctuated, and past tense.