### PR TITLE
improvement: Create download item menu for controlling download items

### DIFF
--- a/src/interfaces/download-item.ts
+++ b/src/interfaces/download-item.ts
@@ -8,6 +8,7 @@ export interface IDownloadItem {
   paused?: boolean;
   canceled?: boolean;
   menuIsOpen?: boolean;
+  openWhenDone?: boolean;
 }
 
 export interface IElectronDownloadItem {

--- a/src/interfaces/download-item.ts
+++ b/src/interfaces/download-item.ts
@@ -3,6 +3,7 @@ export interface IDownloadItem {
   receivedBytes?: number;
   totalBytes?: number;
   savePath?: string;
+  url?: string;
   id?: string;
   completed?: boolean;
   paused?: boolean;

--- a/src/interfaces/download-item.ts
+++ b/src/interfaces/download-item.ts
@@ -5,4 +5,13 @@ export interface IDownloadItem {
   savePath?: string;
   id?: string;
   completed?: boolean;
+  paused?: boolean;
+  canceled?: boolean;
+  menuIsOpen?: boolean;
+}
+
+export interface IElectronDownloadItem {
+  item?: Electron.DownloadItem;
+  webContents?: Electron.WebContents;
+  id?: string;
 }

--- a/src/main/sessions-service.ts
+++ b/src/main/sessions-service.ts
@@ -232,6 +232,7 @@ export class SessionsService {
 
       downloadsDialog()?.send('download-started', downloadItem);
       window.send('download-started', downloadItem);
+      window.send('show-download-dialog');
 
       item.on('updated', (event, state) => {
         if (state === 'interrupted') {
@@ -325,6 +326,7 @@ export class SessionsService {
 
       downloadsDialog()?.send('download-started', downloadItem);
       window.send('download-started', downloadItem);
+      window.send('show-download-dialog');
 
       item.on('updated', (event, state) => {
         if (state === 'interrupted') {

--- a/src/renderer/constants/icons.ts
+++ b/src/renderer/constants/icons.ts
@@ -55,6 +55,7 @@ export const ICON_VOLUME_OFF = require('~/renderer/resources/icons/volume-off.sv
 export const ICON_FULLSCREEN_EXIT = require('~/renderer/resources/icons/fullscreen-exit.svg');
 export const ICON_PAUSE = require('~/renderer/resources/icons/pause.svg');
 export const ICON_RESUME = require('~/renderer/resources/icons/play.svg');
+export const ICON_LINK = require('~/renderer/resources/icons/link.svg');
 
 export const ICON_WEATHER_DAY_CLEAR = require('~/renderer/resources/icons/weather/day/clear.png');
 export const ICON_WEATHER_DAY_FEW_CLOUDS = require('~/renderer/resources/icons/weather/day/few-clouds.png');

--- a/src/renderer/constants/icons.ts
+++ b/src/renderer/constants/icons.ts
@@ -53,6 +53,8 @@ export const ICON_MAGNIFY_MINUS = require('~/renderer/resources/icons/magnify-mi
 export const ICON_VOLUME_HIGH = require('~/renderer/resources/icons/volume-high.svg');
 export const ICON_VOLUME_OFF = require('~/renderer/resources/icons/volume-off.svg');
 export const ICON_FULLSCREEN_EXIT = require('~/renderer/resources/icons/fullscreen-exit.svg');
+export const ICON_PAUSE = require('~/renderer/resources/icons/pause.svg');
+export const ICON_RESUME = require('~/renderer/resources/icons/play.svg');
 
 export const ICON_WEATHER_DAY_CLEAR = require('~/renderer/resources/icons/weather/day/clear.png');
 export const ICON_WEATHER_DAY_FEW_CLOUDS = require('~/renderer/resources/icons/weather/day/few-clouds.png');

--- a/src/renderer/resources/icons/link.svg
+++ b/src/renderer/resources/icons/link.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M17 7h-4v2h4c1.65 0 3 1.35 3 3s-1.35 3-3 3h-4v2h4c2.76 0 5-2.24 5-5s-2.24-5-5-5zm-6 8H7c-1.65 0-3-1.35-3-3s1.35-3 3-3h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-2zm-3-4h8v2H8z"/></svg>

--- a/src/renderer/resources/icons/pause.svg
+++ b/src/renderer/resources/icons/pause.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>

--- a/src/renderer/resources/icons/play.svg
+++ b/src/renderer/resources/icons/play.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M8 5v14l11-7z"/></svg>

--- a/src/renderer/views/app/components/RightButtons/index.tsx
+++ b/src/renderer/views/app/components/RightButtons/index.tsx
@@ -15,11 +15,20 @@ import store from '../../store';
 import { SiteButtons } from '../SiteButtons';
 
 let menuRef: HTMLDivElement = null;
+let downloadDialogRef: HTMLDivElement = null;
 
-const onDownloadsClick = async (e: React.MouseEvent<HTMLDivElement>) => {
-  const { right, bottom } = e.currentTarget.getBoundingClientRect();
+const showDownloadDialog = async () => {
+  const { right, bottom } = downloadDialogRef.getBoundingClientRect();
   store.downloadNotification = false;
   ipcRenderer.send(`show-downloads-dialog-${store.windowId}`, right, bottom);
+};
+
+ipcRenderer.on('show-download-dialog', () => {
+  showDownloadDialog();
+});
+
+const onDownloadsClick = async (e: React.MouseEvent<HTMLDivElement>) => {
+  showDownloadDialog();
 };
 
 const showMenuDialog = async () => {
@@ -65,6 +74,7 @@ export const RightButtons = observer(() => {
 
       {store.downloadsButtonVisible && (
         <ToolbarButton
+          divRef={(r) => (downloadDialogRef = r)}
           size={18}
           badge={store.downloadNotification}
           onMouseDown={onDownloadsClick}

--- a/src/renderer/views/app/store/index.ts
+++ b/src/renderer/views/app/store/index.ts
@@ -216,6 +216,12 @@ export class Store {
       this.downloadsButtonVisible = true;
     });
 
+    ipcRenderer.on('download-removed', (e, id: string) => {
+      const downloads = this.downloads.filter((x) => x.id !== id);
+      this.downloadsButtonVisible = downloads.length > 0;
+      this.downloads = downloads;
+    });
+
     ipcRenderer.on('download-progress', (e, item: IDownloadItem) => {
       const index = this.downloads.findIndex((x) => x.id === item.id);
       this.downloads[index] = {

--- a/src/renderer/views/app/store/index.ts
+++ b/src/renderer/views/app/store/index.ts
@@ -84,15 +84,17 @@ export class Store {
   // Computed
 
   public get downloadProgress() {
-    const downloading = this.downloads.filter((x) => !x.completed);
+    const downloading = this.downloads.filter(
+      (x) => !x.completed && !x.canceled && !x.paused,
+    );
 
     if (downloading.length === 0) return 0;
 
-    const { totalBytes } = this.downloads.reduce((prev, cur) => ({
+    const { totalBytes } = downloading.reduce((prev, cur) => ({
       totalBytes: prev.totalBytes + cur.totalBytes,
     }));
 
-    const { receivedBytes } = this.downloads.reduce((prev, cur) => ({
+    const { receivedBytes } = downloading.reduce((prev, cur) => ({
       receivedBytes: prev.receivedBytes + cur.receivedBytes,
     }));
 
@@ -215,8 +217,11 @@ export class Store {
     });
 
     ipcRenderer.on('download-progress', (e, item: IDownloadItem) => {
-      const i = this.downloads.find((x) => x.id === item.id);
-      i.receivedBytes = item.receivedBytes;
+      const index = this.downloads.findIndex((x) => x.id === item.id);
+      this.downloads[index] = {
+        ...this.downloads[index],
+        ...item,
+      };
     });
 
     ipcRenderer.on('is-bookmarked', (e, flag) => {
@@ -229,15 +234,22 @@ export class Store {
         const i = this.downloads.find((x) => x.id === id);
         i.completed = true;
 
-        if (this.downloads.filter((x) => !x.completed).length === 0) {
-          this.downloads = [];
-        }
-
         if (downloadNotification) {
           this.downloadNotification = true;
         }
       },
     );
+
+    ipcRenderer.on('download-paused', (e, id: string) => {
+      const i = this.downloads.find((x) => x.id === id);
+      i.paused = true;
+    });
+
+    ipcRenderer.on('download-canceled', (e, id: string) => {
+      const i = this.downloads.find((x) => x.id === id);
+      i.completed = false;
+      i.canceled = true;
+    });
 
     ipcRenderer.on('find', () => {
       const tab = this.tabs.selectedTab;

--- a/src/renderer/views/downloads-dialog/components/App/index.tsx
+++ b/src/renderer/views/downloads-dialog/components/App/index.tsx
@@ -27,9 +27,12 @@ export const App = observer(() => {
         onClick={dialogClicked}
       >
         <UIStyle />
-        {store.downloads.map((item) => (
-          <DownloadItem item={item} key={item.id}></DownloadItem>
-        ))}
+        {store.downloads
+          .slice()
+          .reverse()
+          .map((item) => (
+            <DownloadItem item={item} key={item.id}></DownloadItem>
+          ))}
       </StyledApp>
     </ThemeProvider>
   );

--- a/src/renderer/views/downloads-dialog/components/App/index.tsx
+++ b/src/renderer/views/downloads-dialog/components/App/index.tsx
@@ -8,13 +8,24 @@ import { DownloadItem } from '../DownloadItem';
 import { ipcRenderer } from 'electron';
 import { UIStyle } from '~/renderer/mixins/default-styles';
 
+const dialogClicked = (e: React.MouseEvent<HTMLDivElement>) => {
+  store.closeAllDownloadMenu();
+};
+
 export const App = observer(() => {
-  const height = 8 + Math.min(8, store.downloads.length) * (64 + 8);
+  const height =
+    8 +
+    Math.min(8, store.downloads.length) * (64 + 8) +
+    (store.downloads.find((x) => x.menuIsOpen === true) ? 200 : 0);
   ipcRenderer.send(`height-${store.id}`, height);
 
   return (
     <ThemeProvider theme={{ ...store.theme }}>
-      <StyledApp style={{ maxHeight: store.maxHeight }} visible={store.visible}>
+      <StyledApp
+        style={{ maxHeight: store.maxHeight, overflow: 'unset' }}
+        visible={store.visible}
+        onClick={dialogClicked}
+      >
         <UIStyle />
         {store.downloads.map((item) => (
           <DownloadItem item={item} key={item.id}></DownloadItem>

--- a/src/renderer/views/downloads-dialog/components/App/style.ts
+++ b/src/renderer/views/downloads-dialog/components/App/style.ts
@@ -3,7 +3,6 @@ import { ITheme } from '~/interfaces';
 import { DialogStyle } from '~/renderer/mixins/dialogs';
 
 export const StyledApp = styled(DialogStyle)`
-  overflow: overlay;
   padding: 8px;
   font-size: 13px;
 

--- a/src/renderer/views/downloads-dialog/components/DownloadItem/index.tsx
+++ b/src/renderer/views/downloads-dialog/components/DownloadItem/index.tsx
@@ -14,6 +14,8 @@ import {
 import { IDownloadItem } from '~/interfaces';
 import prettyBytes = require('pretty-bytes');
 import { shell } from 'electron';
+import store from '../../store';
+import { DownloadItemMenu } from '../DownloadItemMenu';
 
 const onClick = (item: IDownloadItem) => () => {
   if (item.completed) {
@@ -21,11 +23,11 @@ const onClick = (item: IDownloadItem) => () => {
   }
 };
 
-const onMoreClick = (item: IDownloadItem) => (
-  e: React.MouseEvent<HTMLDivElement>,
-) => {
-  e.stopPropagation();
-};
+const onMoreClick =
+  (item: IDownloadItem) => (e: React.MouseEvent<HTMLDivElement>) => {
+    store.openMenu(item);
+    e.stopPropagation();
+  };
 
 export const DownloadItem = observer(({ item }: { item: IDownloadItem }) => {
   let received = prettyBytes(item.receivedBytes);
@@ -41,8 +43,8 @@ export const DownloadItem = observer(({ item }: { item: IDownloadItem }) => {
     <StyledDownloadItem onClick={onClick(item)}>
       <Icon></Icon>
       <Info>
-        <Title>{item.fileName}</Title>
-        {!item.completed && (
+        <Title canceled={item.canceled}>{item.fileName}</Title>
+        {!item.completed && !item.canceled && (
           <>
             <ProgressBackground>
               <Progress
@@ -51,12 +53,19 @@ export const DownloadItem = observer(({ item }: { item: IDownloadItem }) => {
                 }}
               ></Progress>
             </ProgressBackground>
-            <SecondaryText>{`${received}/${total}`}</SecondaryText>
+            <SecondaryText>{`${received}/${total} ${
+              item.paused ? ', Paused' : ''
+            }`}</SecondaryText>
           </>
         )}
+        {item.canceled && <SecondaryText>Canceled</SecondaryText>}
       </Info>
       <Separator></Separator>
-      <MoreButton onClick={onMoreClick(item)}></MoreButton>
+      <MoreButton
+        toggled={item.menuIsOpen}
+        onClick={onMoreClick(item)}
+      ></MoreButton>
+      <DownloadItemMenu item={item} visible={item.menuIsOpen} />
     </StyledDownloadItem>
   );
 });

--- a/src/renderer/views/downloads-dialog/components/DownloadItem/style.ts
+++ b/src/renderer/views/downloads-dialog/components/DownloadItem/style.ts
@@ -10,7 +10,6 @@ export const StyledDownloadItem = styled.div`
   display: flex;
   align-items: center;
   position: relative;
-  overflow: hidden;
   margin-top: 8px;
   transition: 0.1s background-color, 0.1s border;
 
@@ -34,6 +33,9 @@ export const StyledDownloadItem = styled.div`
 export const Title = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
+  ${({ canceled }: { canceled?: boolean }) => css`
+    text-decoration: ${canceled ? 'line-through' : 'none'};
+  `}
 `;
 
 export const SecondaryText = styled.div`
@@ -98,8 +100,9 @@ export const MoreButton = styled.div`
   border-radius: 6px;
   transition: 0.1s background-color;
 
-  ${({ theme }: { theme?: ITheme }) => css`
+  ${({ theme, toggled }: { theme?: ITheme; toggled?: boolean }) => css`
     filter: ${theme['dialog.lightForeground'] ? 'invert(100%)' : ''};
+    background-color: ${toggled ? 'rgba(0, 0, 0, 0.08)' : 'transparent'};
   `}
 
   &:hover {

--- a/src/renderer/views/downloads-dialog/components/DownloadItemMenu/index.tsx
+++ b/src/renderer/views/downloads-dialog/components/DownloadItemMenu/index.tsx
@@ -2,13 +2,34 @@ import * as React from 'react';
 import { observer } from 'mobx-react-lite';
 import { IDownloadItem } from '~/interfaces';
 import { clipboard, ipcRenderer, remote, shell } from 'electron';
-import { ICON_PAUSE, ICON_RESUME, ICON_CLOSE } from '~/renderer/constants';
+import {
+  ICON_PAUSE,
+  ICON_RESUME,
+  ICON_CLOSE,
+  ICON_CHECK,
+} from '~/renderer/constants';
 import store from '../../store';
 import {
   ContextMenu,
   ContextMenuItem,
   ContextMenuSeparator,
 } from '~/renderer/components/ContextMenu';
+
+const openItem =
+  (item: IDownloadItem) => (e: React.MouseEvent<HTMLDivElement>) => {
+    if (item.completed) {
+      shell.openPath(item.savePath);
+      store.closeAllDownloadMenu();
+      e.stopPropagation();
+    }
+  };
+
+const toggleOpenWhenDone =
+  (item: IDownloadItem) => (e: React.MouseEvent<HTMLDivElement>) => {
+    store.toggleOpenWhenDone(item);
+    store.closeAllDownloadMenu();
+    e.stopPropagation();
+  };
 
 const pauseDownload =
   (item: IDownloadItem) => (e: React.MouseEvent<HTMLDivElement>) => {
@@ -43,6 +64,22 @@ export const DownloadItemMenu = observer(
         }}
         visible={visible}
       >
+        {!item.canceled &&
+          (item.completed ? (
+            <ContextMenuItem onClick={openItem(item)} icon={' '}>
+              Open file
+            </ContextMenuItem>
+          ) : (
+            <ContextMenuItem
+              onClick={toggleOpenWhenDone(item)}
+              icon={item.openWhenDone ? ICON_CHECK : ' '}
+            >
+              Open when done
+            </ContextMenuItem>
+          ))}
+
+        {!item.canceled && <ContextMenuSeparator />}
+
         {!item.completed &&
           !item.canceled &&
           (item.paused ? (

--- a/src/renderer/views/downloads-dialog/components/DownloadItemMenu/index.tsx
+++ b/src/renderer/views/downloads-dialog/components/DownloadItemMenu/index.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { observer } from 'mobx-react-lite';
+import { IDownloadItem } from '~/interfaces';
+import { clipboard, ipcRenderer, remote, shell } from 'electron';
+import { ICON_PAUSE, ICON_RESUME, ICON_CLOSE } from '~/renderer/constants';
+import store from '../../store';
+import {
+  ContextMenu,
+  ContextMenuItem,
+  ContextMenuSeparator,
+} from '~/renderer/components/ContextMenu';
+
+const pauseDownload =
+  (item: IDownloadItem) => (e: React.MouseEvent<HTMLDivElement>) => {
+    ipcRenderer.send('download-pause', item.id);
+    store.closeAllDownloadMenu();
+    e.stopPropagation();
+  };
+
+const resumeDownload =
+  (item: IDownloadItem) => (e: React.MouseEvent<HTMLDivElement>) => {
+    ipcRenderer.send('download-resume', item.id);
+    store.closeAllDownloadMenu();
+    e.stopPropagation();
+  };
+
+const cancelDownload =
+  (item: IDownloadItem) => (e: React.MouseEvent<HTMLDivElement>) => {
+    ipcRenderer.send('download-cancel', item.id);
+    store.closeAllDownloadMenu();
+    e.stopPropagation();
+  };
+
+export const DownloadItemMenu = observer(
+  ({ item, visible }: { item: IDownloadItem; visible: boolean }) => {
+    return (
+      <ContextMenu
+        style={{
+          top: 50,
+          right: 10,
+          width: 200,
+          fontSize: 12,
+        }}
+        visible={visible}
+      >
+        {!item.completed &&
+          !item.canceled &&
+          (item.paused ? (
+            <ContextMenuItem onClick={resumeDownload(item)} icon={ICON_RESUME}>
+              Resume
+            </ContextMenuItem>
+          ) : (
+            <ContextMenuItem onClick={pauseDownload(item)} icon={ICON_PAUSE}>
+              Pause
+            </ContextMenuItem>
+          ))}
+        <ContextMenuSeparator />
+        {!item.completed && !item.canceled && (
+          <ContextMenuItem onClick={cancelDownload(item)} icon={ICON_CLOSE}>
+            Cancel
+          </ContextMenuItem>
+        )}
+      </ContextMenu>
+    );
+  },
+);

--- a/src/renderer/views/downloads-dialog/components/DownloadItemMenu/style.tsx
+++ b/src/renderer/views/downloads-dialog/components/DownloadItemMenu/style.tsx
@@ -1,0 +1,1 @@
+import styled, { css } from 'styled-components';

--- a/src/renderer/views/downloads-dialog/store/index.ts
+++ b/src/renderer/views/downloads-dialog/store/index.ts
@@ -1,4 +1,4 @@
-import { ipcRenderer } from 'electron';
+import { ipcRenderer, shell } from 'electron';
 import { action, makeObservable, observable } from 'mobx';
 import { IDownloadItem } from '~/interfaces';
 import { DialogStore } from '~/models/dialog-store';
@@ -33,6 +33,9 @@ export class Store extends DialogStore {
     ipcRenderer.on('download-completed', (e, id: string) => {
       const i = this.downloads.find((x) => x.id === id);
       i.completed = true;
+      if (i.openWhenDone) {
+        shell.openPath(i.savePath);
+      }
     });
 
     ipcRenderer.on('download-paused', (e, id: string) => {
@@ -76,6 +79,18 @@ export class Store extends DialogStore {
       menuIsOpen: false,
     }));
     this.downloads = downloads;
+  }
+
+  @action
+  public toggleOpenWhenDone(item: IDownloadItem) {
+    const index = this.downloads.indexOf(
+      this.downloads.find((x) => x.id === item.id),
+    );
+
+    this.downloads[index] = {
+      ...this.downloads[index],
+      openWhenDone: !this.downloads[index].openWhenDone,
+    };
   }
 }
 

--- a/src/renderer/views/downloads-dialog/store/index.ts
+++ b/src/renderer/views/downloads-dialog/store/index.ts
@@ -49,6 +49,20 @@ export class Store extends DialogStore {
       i.canceled = true;
     });
 
+    ipcRenderer.on('download-removed', (e, id: string) => {
+      this.downloads = this.downloads.filter((x) => x.id !== id);
+    });
+
+    ipcRenderer.on(
+      'download-open-when-done-change',
+      (e, item: IDownloadItem) => {
+        const index = this.downloads.indexOf(
+          this.downloads.find((x) => x.id === item.id),
+        );
+        this.downloads[index].openWhenDone = item.openWhenDone;
+      },
+    );
+
     ipcRenderer.on('max-height', (e, height) => {
       this.maxHeight = height;
     });
@@ -79,18 +93,6 @@ export class Store extends DialogStore {
       menuIsOpen: false,
     }));
     this.downloads = downloads;
-  }
-
-  @action
-  public toggleOpenWhenDone(item: IDownloadItem) {
-    const index = this.downloads.indexOf(
-      this.downloads.find((x) => x.id === item.id),
-    );
-
-    this.downloads[index] = {
-      ...this.downloads[index],
-      openWhenDone: !this.downloads[index].openWhenDone,
-    };
   }
 }
 


### PR DESCRIPTION
#### Description of Change

improvement: Create download item menu for controlling download items.

- Add Pause, Resume, and Cancel buttons to the download item menu. Closes bug: #587 
- Add Open, Open when done, Show in folder, Copy download link, Delete file, and Remove from list buttons to the download item menu
- Open download dialog when download started
- Change download item order, the last downloaded file will show at the top of the download list

![2021-12-13_2-41-26](https://user-images.githubusercontent.com/21088281/145733574-da2218e9-88cd-4f38-b98d-73dff5544965.gif)

#### Checklist

- [x] PR description included
- [x] PR title follows semantic [commit guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
- [x] PR release notes describe the change, and are capitalized, punctuated, and past tense.
